### PR TITLE
Detect API call on Secondary node

### DIFF
--- a/pyvelop/exceptions.py
+++ b/pyvelop/exceptions.py
@@ -39,6 +39,13 @@ class MeshInvalidInput(Exception):
         super().__init__(args)
 
 
+class MeshNodeNotPrimary(Exception):
+    """API call being used on a node that isn't the primary"""
+
+    def __init__(self) -> None:
+        super().__init__("Node not Primary")
+
+
 class MeshTooManyMatches(Exception):
     """Too many matching devices when only one should be found"""
 

--- a/pyvelop/mesh.py
+++ b/pyvelop/mesh.py
@@ -16,6 +16,7 @@ from .exceptions import (
     MeshInvalidArguments,
     MeshInvalidCredentials,
     MeshInvalidInput,
+    MeshNodeNotPrimary,
     MeshTooManyMatches,
 )
 from .node import Node
@@ -218,6 +219,8 @@ class Mesh:
                         elif resp.get("result") == "_ErrorUnknownAction":
                             # noinspection PyTypeChecker
                             err = MeshInvalidInput("Unknown JNAP Action")
+                        elif resp.get("result") == "ErrorDeviceNotInMasterMode":
+                            err = MeshNodeNotPrimary
                         elif not resp.get("result").startswith("_"):
                             err = MeshInvalidInput(resp.get("result"))
 


### PR DESCRIPTION
Some calls must be executed against the primary node.