### PR TITLE
refactor: type hints and cli overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,8 +132,11 @@ dmypy.json
 .idea/
 tests/
 
+# Package files
+.vscode/
+cli_output/
 doco_package.py
 logo.ico
 *.code-workspace
-.vscode/launch.json
-.vscode/settings.json
+.mypy_*.txt
+mypy_*.txt

--- a/pyvelop/__main__.py
+++ b/pyvelop/__main__.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 import asyncclick as click
+import pandas as pd
 
-from .const import Weekdays
+from .const import MeshCapability, Weekdays
 from .exceptions import (
     MeshConnectionError,
     MeshDeviceNotFoundResponse,
@@ -19,7 +20,8 @@ from .exceptions import (
     MeshNodeNotPrimary,
     MeshTimeoutError,
 )
-from .mesh import Mesh, MeshCapability
+from .logger import set_logging_format
+from .mesh import Mesh
 from .mesh_entity import DeviceEntity, ParentalControl
 
 # endregion
@@ -28,11 +30,13 @@ from .mesh_entity import DeviceEntity, ParentalControl
 class StandardCommand(click.Command):
     """Define standard options that should be used with all commands."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialise."""
         super().__init__(*args, **kwargs)
 
-        def _create_session(ctx: click.Context, param: click.Option, value) -> None:
+        def _create_session(
+            ctx: click.Context, param: click.Option, value: Any
+        ) -> None:
             """Create the session and store for late use."""
             if param.name == "create_session":
                 if value:
@@ -41,11 +45,15 @@ class StandardCommand(click.Command):
                         aiohttp.ClientSession(raise_for_status=True)
                     )
 
-        def _setup_logging(_: click.Context, param: click.Option, value) -> None:
+        def _setup_logging(_: click.Context, param: click.Option, value: Any) -> None:
             """Handle logging."""
             if param.name == "verbose":
                 if value:
-                    logging.basicConfig()
+                    logging.basicConfig(
+                        format=set_logging_format(
+                            include_func_name=True, include_lineno=True
+                        )
+                    )
                     _LOGGER.setLevel(logging.DEBUG)
                     _LOGGER.debug("Setting up logging")
                     if value > 1:
@@ -159,8 +167,9 @@ async def device_group() -> None:
 @click.argument("device")
 async def device_delete(
     ctx: click.Context,
+    /,
     device: str,
-    **_,
+    **_: Any,
 ) -> None:
     """Delete a device on the Mesh."""
 
@@ -172,53 +181,83 @@ async def device_delete(
             try:
                 await found_device.async_delete()
             except Exception as exc:
-                click.echo(click.style(exc, fg="red"))
+                _write_error(exc)
 
 
 @device_group.command(cls=StandardCommand, name="details")
 @click.pass_context
 @click.argument("device", nargs=-1)
+@click.option("--outfile", default=None, required=False)
 async def device_details(
     ctx: click.Context,
+    /,
     device: tuple[str, ...],
-    **_,
+    outfile: str | None = None,
+    **_: Any,
 ) -> None:
     """Display details about a device on the Mesh."""
     devices = await _get_device_details(ctx=ctx, device=device)
 
     if devices is not None:
+        _output(outfile, "# Device Details\n")
         for found_device in devices:
             try:
-                title: str = found_device.name
-                click.echo(title)
-                click.echo("-" * len(title))
-                _display_value("Queried at", found_device.results_time)
-                _display_value("Device ID", found_device.unique_id)
-                _display_value("Online", found_device.status)
-                _display_value("Parent", found_device.parent_name)
-                _display_value("Manufacturer", found_device.manufacturer)
-                _display_value("Model", found_device.model)
-                _display_value("Description", found_device.description)
-                _display_value("Operating system", found_device.operating_system)
-                _display_value("Serial #", found_device.serial)
-                _display_value("Icon type", found_device.ui_type)
-                _display_value("Connections", found_device.adapter_info)
-                _display_value(
-                    "Parental Control",
-                    {
-                        "Blocked sites": found_device.parental_control_schedule.get(
-                            "blocked_sites"
-                        ),
-                        "Schedule": [
-                            f"{day.title()}\t{','.join(sched)}"
-                            for day, sched in found_device.parental_control_schedule.get(
-                                "blocked_internet_access", {}
-                            ).items()
-                        ],
-                    },
+                data: dict[str, Any] = {
+                    "Queried at": found_device.results_time,
+                    "Device ID": found_device.unique_id,
+                    "Online": found_device.status,
+                    "Parent": found_device.parent_name,
+                    "Manufacturer": found_device.manufacturer,
+                    "Model": found_device.model,
+                    "Description": found_device.description,
+                    "Operating system": found_device.operating_system,
+                    "Serial #": found_device.serial,
+                    "Icon type": found_device.ui_type,
+                }
+                _display(
+                    outfile,
+                    pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                    index=True,
+                    title=found_device.name,
                 )
+                _display(
+                    outfile,
+                    pd.DataFrame(found_device.adapter_info),
+                    title="# Connections",
+                )
+                if (
+                    num_blocked_sites := len(
+                        found_device.parental_control_schedule.get("blocked_sites", [])
+                    )
+                    > 0
+                ):
+                    _display(
+                        outfile,
+                        pd.DataFrame(
+                            found_device.parental_control_schedule.get("blocked_sites"),
+                            columns=["site"],
+                        ),
+                        title="Parental Control",
+                    )
+                if num_blocked_sites == 0 and (
+                    schedule := found_device.parental_control_schedule.get(
+                        "blocked_internet_access", {}
+                    )
+                ):
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(schedule, orient="index"),
+                        index=True,
+                        title="Parental Control",
+                    )
+                else:
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(schedule, orient="index"),
+                        index=True,
+                    )
             except Exception as exc:
-                click.echo(click.style(exc, fg="red"))
+                _write_error(exc)
 
 
 @device_group.command(cls=StandardCommand, name="internet_access")
@@ -227,14 +266,17 @@ async def device_details(
 @click.option("--block/--no-block", default=False)
 async def device_internet_access(
     ctx: click.Context,
+    /,
     device_id: str,
     block: bool,
-    **_,
+    **_: Any,
 ) -> None:
     """Block/Unblock access to the internet."""
-    if mesh_obj := await _async_mesh_connect(ctx):
-        async with mesh_obj:
-            await mesh_obj.async_gather_details()
+    dev_id = (device_id,)
+    devices = await _get_device_details(ctx, dev_id)
+
+    if devices is not None:
+        for found_device in devices:
             try:
                 if not block:
                     rules_to_apply = {}
@@ -249,9 +291,9 @@ async def device_internet_access(
                             ("00:00-00:00",) * len(Weekdays),
                         )
                     )
-                await mesh_obj.async_set_parental_control_rules(
-                    device_id=device_id,
+                await found_device.async_set_parental_control_rules(
                     rules=rules_to_apply,
+                    force_enable=True,
                 )
             except MeshDeviceNotFoundResponse as err:
                 _LOGGER.error("Device not found: %s", err.devices[0])
@@ -263,7 +305,9 @@ async def device_internet_access(
 @click.pass_context
 @click.argument("device_id")
 @click.argument("new_name")
-async def device_rename(ctx: click.Context, device_id: str, new_name: str, **_) -> None:
+async def device_rename(
+    ctx: click.Context, /, device_id: str, new_name: str, **_: Any
+) -> None:
     """Rename the given device."""
 
     dev_id = (device_id,)
@@ -274,23 +318,30 @@ async def device_rename(ctx: click.Context, device_id: str, new_name: str, **_) 
             try:
                 await found_device.async_rename(new_name)
             except Exception as exc:
-                click.echo(click.style(exc, fg="red"))
+                _write_error(exc)
 
 
 @device_group.command(cls=StandardCommand, name="set_icon")
 @click.pass_context
 @click.argument("device_id")
 @click.argument("icon")
-async def device_set_icon(ctx: click.Context, device_id: str, icon: str, **_) -> None:
+async def device_set_icon(
+    ctx: click.Context, /, device_id: str, icon: str, **_: Any
+) -> None:
     """Set the icon for the given device."""
 
     try:
-        if mesh_obj := await _async_mesh_connect(ctx):
-            async with mesh_obj:
-                await mesh_obj.async_set_device_icon(device_id, icon.lower())
+        dev_id = (device_id,)
+        devices = await _get_device_details(ctx, dev_id)
+        if devices is not None:
+            for found_device in devices:
+                try:
+                    await found_device.async_set_icon(icon.lower())
+                except Exception as exc:
+                    _write_error(exc)
     except Exception as exc:
         _LOGGER.error(exc)
-        click.echo(click.style(exc, fg="red"), err=True)
+        _write_error(exc)
 
 
 @device_group.command(cls=StandardCommand, name="set_rules")
@@ -305,6 +356,7 @@ async def device_set_icon(ctx: click.Context, device_id: str, icon: str, **_) ->
 @click.option("--saturday")
 async def device_pc_set_rules(
     ctx: click.Context,
+    /,
     device_id: str,
     sunday: str,
     monday: str,
@@ -313,7 +365,7 @@ async def device_pc_set_rules(
     thursday: str,
     friday: str,
     saturday: str,
-    **_,
+    **_: Any,
 ) -> None:
     """Set the parental control rules."""
 
@@ -337,7 +389,7 @@ async def device_pc_set_rules(
                     force_enable=True,
                 )
     except Exception as exc:
-        click.echo(click.style(exc, fg="red"))
+        _write_error(exc)
 
 
 @device_group.command(cls=StandardCommand, name="set_urls")
@@ -346,7 +398,7 @@ async def device_pc_set_rules(
 @click.argument("urls", nargs=-1)
 @click.option("--merge/--no-merge", default=True)
 async def device_pc_set_urls(
-    ctx: click.Context, device_id: str, merge: bool, urls: tuple[str, ...], **_
+    ctx: click.Context, /, device_id: str, merge: bool, urls: tuple[str, ...], **_: Any
 ) -> None:
     """Set the parental control URLs."""
 
@@ -362,7 +414,7 @@ async def device_pc_set_urls(
                     merge=merge,
                 )
             except Exception as exc:
-                click.echo(click.style(exc, fg="red"))
+                _write_error(exc)
 
 
 @cli.group(name="mesh")
@@ -372,10 +424,13 @@ async def mesh_group() -> None:
 
 
 @mesh_group.command(cls=StandardCommand, name="details")
+@click.option("--outfile", default=None, required=False)
 @click.pass_context
 async def mesh_details(
     ctx: click.Context,
-    **_,
+    /,
+    outfile: str | None = None,
+    **_: Any,
 ) -> None:
     """Get details about the Mesh."""
 
@@ -384,112 +439,226 @@ async def mesh_details(
             try:
                 await mesh_obj.async_initialise()
             except Exception as exc:
-                click.echo(click.style(exc, fg="red"), err=True)
-                return
+                _write_error(exc)
+                return None
 
             try:
-                title: str = "Mesh Details"
-                click.echo(title)
-                click.echo("-" * len(title))
-                _display_value("Capabilities", mesh_obj.capabilities)
+                _output(outfile, "# Mesh Details\n")
+                _display(
+                    outfile,
+                    pd.DataFrame(mesh_obj.capabilities, columns=[""]),
+                    title="Capabilities",
+                )
                 if MeshCapability.GET_WAN_INFO in mesh_obj.capabilities:
-                    _display_value("Internet connected", mesh_obj.wan_status)
-                    _display_value("Public IP", mesh_obj.wan_ip)
-                    _display_value("WAN MAC", mesh_obj.wan_mac)
+                    data: dict[str, Any] = {
+                        "Internet connected": mesh_obj.wan_status,
+                        "Public IP": mesh_obj.wan_ip,
+                        "WAN MAC": mesh_obj.wan_mac,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="WAN Info",
+                    )
                 if MeshCapability.GET_LAN_SETTINGS in mesh_obj.capabilities:
-                    _display_value("DHCP enabled", mesh_obj.dhcp_enabled)
-                    _display_value(
-                        "DHCP reservations",
-                        [
-                            f"{r.get('description')}\t{r.get('mac_address')}\t{r.get('ip_address')}"
-                            for r in mesh_obj.dhcp_reservations
-                        ],
+                    data: dict[str, Any] = {
+                        "DHCP enabled": mesh_obj.dhcp_enabled,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="LAN Settings",
+                    )
+                    _display(
+                        outfile,
+                        pd.DataFrame(
+                            mesh_obj.dhcp_reservations,
+                            index=pd.RangeIndex(
+                                start=1, stop=(len(mesh_obj.dhcp_reservations) + 1)
+                            ),
+                        ),
+                        index=True,
+                        title="DHCP Reservations",
                     )
                 if (
                     MeshCapability.GET_TOPOLOGY_OPTIMISATION_SETTINGS
                     in mesh_obj.capabilities
                 ):
-                    _display_value(
-                        "Client steering enabled", mesh_obj.client_steering_enabled
-                    )
-                    _display_value(
-                        "Node steering enabled", mesh_obj.node_steering_enabled
+                    data: dict[str, Any] = {
+                        "Client steering enabled": mesh_obj.client_steering_enabled,
+                        "Node steering enabled": mesh_obj.node_steering_enabled,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="Topology Optimisation Settings",
                     )
                 if MeshCapability.GET_EXPRESS_FORWARDING in mesh_obj.capabilities:
-                    _display_value(
-                        "Express Forwarding",
-                        {
-                            "Supported": mesh_obj.express_forwarding_supported,
-                            "Enabled": mesh_obj.express_forwarding_enabled,
-                        },
+                    data: dict[str, Any] = {
+                        "Supported": mesh_obj.express_forwarding_supported,
+                        "Enabled": mesh_obj.express_forwarding_enabled,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="Express Forwarding",
                     )
                 if MeshCapability.GET_PARENTAL_CONTROL_INFO in mesh_obj.capabilities:
-                    _display_value(
-                        "Parental Control enabled", mesh_obj.parental_control_enabled
+                    data: dict[str, Any] = {
+                        "Enabled": mesh_obj.parental_control_enabled,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="Parental Control",
                     )
                 if MeshCapability.GET_MAC_FILTERING_SETTINGS in mesh_obj.capabilities:
-                    _display_value(
-                        "MAC filtering",
-                        {
-                            "Enabled": mesh_obj.mac_filtering_enabled,
-                            "Mode": mesh_obj.mac_filtering_mode,
-                            "Filters": mesh_obj.mac_filtering_addresses,
-                        },
+                    data: dict[str, Any] = {
+                        "Enabled": mesh_obj.mac_filtering_enabled,
+                        "Mode": mesh_obj.mac_filtering_mode,
+                        "Filters": (
+                            mesh_obj.mac_filtering_addresses
+                            if len(mesh_obj.mac_filtering_addresses) > 0
+                            else None
+                        ),
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="MAC Filtering",
                     )
                 if MeshCapability.GET_WPS_SERVER_SETTINGS in mesh_obj.capabilities:
-                    _display_value("WPS enabled", mesh_obj.wps_state)
+                    data: dict[str, Any] = {
+                        "Enabled": mesh_obj.wps_state,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="WPS Settings",
+                    )
                 if MeshCapability.GET_ALG_SETTINGS in mesh_obj.capabilities:
-                    _display_value("SIP enabled", mesh_obj.sip_enabled)
+                    data: dict[str, Any] = {
+                        "Enabled": mesh_obj.sip_enabled,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="SIP Settings",
+                    )
                 if MeshCapability.GET_HOMEKIT_SETTINGS in mesh_obj.capabilities:
-                    _display_value(
-                        "HomeKit",
-                        {
-                            "Enabled": mesh_obj.homekit_enabled,
-                            "Paired": mesh_obj.homekit_paired,
-                        },
+                    data: dict[str, Any] = {
+                        "Enabled": mesh_obj.homekit_enabled,
+                        "Paired": mesh_obj.homekit_paired,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="HomeKit Settings",
                     )
                 if MeshCapability.GET_UPNP_SETTINGS in mesh_obj.capabilities:
-                    _display_value(
-                        "UPnP",
-                        {
-                            "Enabled": mesh_obj.upnp_enabled,
-                            "allow_change_settings": mesh_obj.upnp_allow_change_settings,
-                            "allow_disable_Internet": mesh_obj.upnp_allow_disable_internet,
-                        },
+                    data: dict[str, Any] = {
+                        "Enabled": mesh_obj.upnp_enabled,
+                        "allow_change_settings": mesh_obj.upnp_allow_change_settings,
+                        "allow_disable_Internet": mesh_obj.upnp_allow_disable_internet,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="UPnP Settings",
                     )
                 if MeshCapability.GET_DEVICES in mesh_obj.capabilities:
-                    _display_value("Nodes", [n.name for n in mesh_obj.nodes])
+                    data_list: list[str | dict[str, Any]] = [
+                        n.name for n in mesh_obj.nodes
+                    ]
+                    _display(
+                        outfile,
+                        pd.DataFrame(
+                            data_list,
+                            columns=["name"],
+                            index=pd.RangeIndex(start=1, stop=(len(data_list) + 1)),
+                        ),
+                        index=True,
+                        title="Nodes",
+                    )
                 if MeshCapability.GET_SPEEDTEST_RESULTS in mesh_obj.capabilities:
-                    _display_value(
-                        "Latest Speedtest result", mesh_obj.latest_speedtest_result
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(
+                            cast(dict[str, Any], mesh_obj.latest_speedtest_result),
+                            orient="index",
+                            columns=[""],
+                        ),
+                        index=True,
+                        title="Speedtest Results (Latest)",
                     )
                 if MeshCapability.GET_GUEST_NETWORK_INFO in mesh_obj.capabilities:
-                    _display_value(
-                        "Guest network",
-                        {
-                            "Enabled": mesh_obj.guest_wifi_enabled,
-                            "Networks": mesh_obj.guest_wifi_details,
-                        },
+                    data: dict[str, Any] = {
+                        "Enabled": mesh_obj.guest_wifi_enabled,
+                    }
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                        index=True,
+                        title="Guest Network Settings",
+                    )
+                    _display(
+                        outfile,
+                        pd.DataFrame.from_dict(
+                            cast(dict[str, Any], mesh_obj.guest_wifi_details)
+                        ),
+                        title="# Networks",
                     )
                 if MeshCapability.GET_STORAGE_PARTITIONS in mesh_obj.capabilities:
-                    _display_value(
-                        "Storage details", {"Shares": mesh_obj.storage_available}
+                    _display(
+                        outfile,
+                        pd.DataFrame(mesh_obj.storage_available),
+                        title="File Shares",
                     )
                 if MeshCapability.GET_DEVICES in mesh_obj.capabilities:
-                    _display_value(
-                        "Online devices",
+                    _LOGGER.debug(
                         [
-                            f"{d.name}\t{d.adapter_info[0].get('ip')}"
+                            {"name": d.name, "ip": d.adapter_info[0].get("ip")}
                             for d in mesh_obj.devices
                             if d.status
-                        ],
+                        ]
                     )
-                    _display_value(
-                        "Offline devices",
-                        [d.name for d in mesh_obj.devices if not d.status],
+                    data_list = [
+                        {"name": d.name, "ip": d.adapter_info[0].get("ip")}
+                        for d in mesh_obj.devices
+                        if d.status
+                    ]
+                    _display(
+                        outfile,
+                        pd.DataFrame(
+                            data_list,
+                            index=pd.RangeIndex(start=1, stop=(len(data_list) + 1)),
+                        ),
+                        index=True,
+                        title="Online Devices",
+                    )
+                    data_list = [d.name for d in mesh_obj.devices if not d.status]
+                    _display(
+                        outfile,
+                        pd.DataFrame(
+                            data_list,
+                            columns=["name"],
+                            index=pd.RangeIndex(start=1, stop=(len(data_list) + 1)),
+                        ),
+                        index=True,
+                        title="Offline Devices",
                     )
             except Exception as exc:
-                click.echo(click.style(exc, fg="red"))
+                _write_error(exc)
 
 
 @mesh_group.command(cls=StandardCommand, name="action")
@@ -499,8 +668,9 @@ async def mesh_details(
 @click.pass_context
 async def mesh_action(
     ctx: click.Context,
+    /,
     action: str,
-    **_,
+    **_: Any,
 ) -> None:
     """Carry out a specified action on the mesh."""
 
@@ -511,32 +681,32 @@ async def mesh_action(
                 if action == "channel_scan_info":
                     ret = await mesh_obj.async_get_channel_scan_info()
                 elif action == "channel_scan_start":
-                    ret = await mesh_obj.async_start_channel_scan()
+                    await mesh_obj.async_start_channel_scan()
                 elif action == "detect_capabilities":
                     ret = await mesh_obj.async_detect_capabilities()
                 elif action == "guest_wifi_off":
-                    ret = await mesh_obj.async_set_guest_wifi_state(state=False)
+                    await mesh_obj.async_set_guest_wifi_state(state=False)
                 elif action == "guest_wifi_on":
-                    ret = await mesh_obj.async_set_guest_wifi_state(state=True)
+                    await mesh_obj.async_set_guest_wifi_state(state=True)
                 elif action == "homekit_off":
-                    ret = await mesh_obj.async_set_homekit_state(state=False)
+                    await mesh_obj.async_set_homekit_state(state=False)
                 elif action == "homekit_on":
-                    ret = await mesh_obj.async_set_homekit_state(state=True)
+                    await mesh_obj.async_set_homekit_state(state=True)
                 elif action == "parental_control_off":
-                    ret = await mesh_obj.async_set_parental_control_state(state=False)
+                    await mesh_obj.async_set_parental_control_state(state=False)
                 elif action == "parental_control_on":
-                    ret = await mesh_obj.async_set_parental_control_state(state=True)
+                    await mesh_obj.async_set_parental_control_state(state=True)
                 elif action == "speedtest_results":
                     ret = await mesh_obj.async_get_speedtest_results()
                 elif action == "speedtest_start":
-                    ret = await mesh_obj.async_start_speedtest()
+                    await mesh_obj.async_start_speedtest()
                 elif action == "speedtest_state":
                     ret = await mesh_obj.async_get_speedtest_state()
                 elif action == "update_check_start":
-                    ret = await mesh_obj.async_check_for_updates()
+                    await mesh_obj.async_check_for_updates()
                 elif action == "upnp_off":
                     cur_settings = await mesh_obj.async_get_upnp_state()
-                    new_settings: dict[str, bool] = {
+                    new_upnp_settings_off: dict[str, bool] = {
                         "enabled": False,
                         "allow_change_settings": cur_settings.get(
                             "canUsersConfigure", False
@@ -545,10 +715,10 @@ async def mesh_action(
                             "canUsersDisableWANAccess", False
                         ),
                     }
-                    ret = await mesh_obj.async_set_upnp_settings(**new_settings)
+                    await mesh_obj.async_set_upnp_settings(**new_upnp_settings_off)
                 elif action == "upnp_on":
                     cur_settings = await mesh_obj.async_get_upnp_state()
-                    new_settings: dict[str, bool] = {
+                    new_upnp_settings_on: dict[str, bool] = {
                         "enabled": True,
                         "allow_change_settings": cur_settings.get(
                             "canUsersConfigure", False
@@ -557,15 +727,15 @@ async def mesh_action(
                             "canUsersDisableWANAccess", False
                         ),
                     }
-                    ret = await mesh_obj.async_set_upnp_settings(**new_settings)
+                    await mesh_obj.async_set_upnp_settings(**new_upnp_settings_on)
                 elif action == "wps_off":
-                    ret = await mesh_obj.async_set_wps_state(state=False)
+                    await mesh_obj.async_set_wps_state(state=False)
                 elif action == "wps_on":
-                    ret = await mesh_obj.async_set_wps_state(state=True)
+                    await mesh_obj.async_set_wps_state(state=True)
     except Exception as exc:
-        click.echo(click.style(exc, fg="red"), err=True)
+        _write_error(exc)
     else:
-        click.echo(ret)
+        _output(None, ret)
 
 
 @cli.group(name="node")
@@ -576,11 +746,14 @@ async def node_group() -> None:
 
 @node_group.command(cls=StandardCommand, name="details")
 @click.argument("node_name")
+@click.option("--outfile", default=None, required=False)
 @click.pass_context
 async def node_details(
     ctx: click.Context,
+    /,
     node_name: str,
-    **_,
+    outfile: str | None = None,
+    **_: Any,
 ) -> None:
     """Get details about a node on the Mesh."""
     if mesh_obj := await _async_mesh_connect(ctx):
@@ -597,41 +770,75 @@ async def node_details(
                     click.echo("Node not found")
                 else:
                     try:
-                        title: str = node_name
-                        click.echo(title)
-                        click.echo("-" * len(title))
-                        _display_value("Queried at", found_node.results_time)
-                        _display_value("Device ID", found_node.unique_id)
-                        _display_value("Online", found_node.status)
-                        _display_value("Node type", found_node.type.title())
-                        _display_value("Manufacturer", found_node.manufacturer)
-                        _display_value("Model", found_node.model)
-                        _display_value("Hardware version", found_node.hardware_version)
-                        _display_value("Serial #", found_node.serial)
-                        _display_value("Icon type", found_node.ui_type)
-                        _display_value(
-                            "Firmware details",
-                            {
-                                "Versions": found_node.firmware,
-                                "last_checked": found_node.last_update_check,
-                            },
+                        _output(outfile, f"# Node: {node_name}\n")
+                        data: dict[str, Any] = {
+                            "Queried at": found_node.results_time,
+                            "Device ID": found_node.unique_id,
+                            "Online": found_node.status,
+                            "Node type": found_node.type.title(),
+                            "Manufacturer": found_node.manufacturer,
+                            "Model": found_node.model,
+                            "Hardware version": found_node.hardware_version,
+                            "Serial #": found_node.serial,
+                            "Icon type": found_node.ui_type,
+                        }
+                        _display(
+                            outfile,
+                            pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                            index=True,
                         )
-                        _display_value("Connections", found_node.adapter_info)
+                        data: dict[str, Any] = {
+                            "Last Checked": found_node.last_update_check,
+                        }
+                        _display(
+                            outfile,
+                            pd.DataFrame.from_dict(data, orient="index", columns=[""]),
+                            index=True,
+                            title="Firmware details",
+                        )
+                        _display(
+                            outfile,
+                            pd.DataFrame([found_node.firmware]),
+                        )
+                        _display(
+                            outfile,
+                            pd.DataFrame(
+                                found_node.adapter_info,
+                                index=list(range(len(found_node.adapter_info))),
+                            ),
+                            title="Connections",
+                        )
                         if found_node.type == "secondary":
-                            _display_value(
-                                "Backhaul",
-                                {
-                                    "details": [found_node.backhaul],
-                                    "parent": f"{found_node.parent_name} ({found_node.parent_ip})",
-                                },
-                                include_count_on_list=False,
+                            data: dict[str, Any] = {
+                                "parent": f"{found_node.parent_name} ({found_node.parent_ip})",
+                                **found_node.backhaul,
+                            }
+                            _display(
+                                outfile,
+                                pd.DataFrame.from_dict(
+                                    data, orient="index", columns=[""]
+                                ),
+                                index=True,
+                                title="Backhaul",
                             )
-                        _display_value(
-                            "Connected Devices",
-                            [d.get("name", "") for d in found_node.connected_devices],
+                        _display(
+                            outfile,
+                            pd.DataFrame(
+                                [
+                                    d.get("name", "")
+                                    for d in found_node.connected_devices
+                                ],
+                                columns=["device"],
+                                index=pd.RangeIndex(
+                                    start=1,
+                                    stop=(len(found_node.connected_devices) + 1),
+                                ),
+                            ),
+                            index=True,
+                            title="Connected Devices",
                         )
                     except Exception as exc:
-                        click.echo(click.style(exc, fg="red"))
+                        _write_error(exc)
 
 
 @node_group.command(cls=StandardCommand, name="restart")
@@ -639,8 +846,9 @@ async def node_details(
 @click.pass_context
 async def node_restart(
     ctx: click.Context,
+    /,
     node_name: str,
-    **_,
+    **_: Any,
 ) -> None:
     """Restart a node on the Mesh."""
 
@@ -660,8 +868,7 @@ async def node_restart(
                     try:
                         await found_node.async_reboot()
                     except Exception as exc:
-                        click.echo(click.style(exc, fg="red"), err=True)
-                        return
+                        _write_error(exc)
 
 
 @cli.group(name="parental_schedules")
@@ -675,7 +882,12 @@ async def ps_all_blocked() -> None:
     """Display the all unblocked binary code."""
 
     ret = ParentalControl.ALL_PAUSED_SCHEDULE()
-    _display_value("", ret)
+    _display(
+        None,
+        pd.DataFrame.from_dict(ret, orient="index", columns=["binary_string"]),
+        index=True,
+        title="All Blocked",
+    )
 
 
 @parental_schedule_group.command(name="all_unblocked")
@@ -683,7 +895,12 @@ async def ps_all_unblocked() -> None:
     """Display the all unblocked binary code."""
 
     ret = ParentalControl.ALL_ALLOWED_SCHEDULE()
-    _display_value("", ret)
+    _display(
+        None,
+        pd.DataFrame.from_dict(ret, orient="index", columns=["binary_string"]),
+        index=True,
+        title="All Unblocked",
+    )
 
 
 @parental_schedule_group.command(name="decode")
@@ -705,7 +922,7 @@ async def ps_decode(
 ) -> None:
     """Decode the given binary schedule forms to a human readable form."""
 
-    ret = {}
+    ret: dict[str, Any] = {}
     dict_to_encode: dict[str, Any] = {
         day.name.lower(): (
             locals().get(day.name.lower()) if locals().get(day.name.lower()) else None
@@ -716,11 +933,20 @@ async def ps_decode(
         dict_to_encode
     )
     if isinstance(decoded, dict):
+        num_columns: int = -1
         for day in Weekdays:
             if locals().get(day.name.lower()) is not None:
                 ret[day.name.lower()] = decoded.get(day.name.lower())
+                if len(ret[day.name.lower()]) > num_columns:
+                    num_columns = len(ret[day.name.lower()])
 
-    _display_value("", ret)
+    _display(
+        None,
+        pd.DataFrame.from_dict(
+            ret, orient="index", columns=["" for _ in range(0, num_columns)]
+        ),
+        index=True,
+    )
 
 
 @parental_schedule_group.command(name="encode")
@@ -757,7 +983,11 @@ async def ps_encode(
             if locals().get(day.name.lower()) is not None:
                 ret[day.name.lower()] = encoded.get(day.name.lower())
 
-    _display_value("", ret)
+    _display(
+        None,
+        pd.DataFrame.from_dict(ret, orient="index", columns=["binary_string"]),
+        index=True,
+    )
 
 
 @parental_schedule_group.command(name="encode_for_backup")
@@ -787,7 +1017,7 @@ async def ps_encode_for_backup(
     }
     encoded: str | dict[str, Any] = ParentalControl.human_readable_to_binary(to_backup)
     if isinstance(encoded, dict):
-        _display_value("", ParentalControl.encode_for_backup(encoded))
+        _output(None, ParentalControl.encode_for_backup(encoded))
 
 
 async def _async_mesh_connect(ctx: click.Context | None = None) -> Mesh | None:
@@ -818,68 +1048,53 @@ async def _async_mesh_connect(ctx: click.Context | None = None) -> Mesh | None:
             return mesh_object
 
         if msg != "":
-            click.echo(click.style(msg, fg="red"))
+            _write_error(msg)
 
     return None
 
 
-def _display_value(
-    label: str,
-    value: Any,
-    display_bool_false: str = "No",
-    display_bool_true: str = "Yes",
-    display_none: str = "N/A",
-    indent_level: int = 0,
-    include_count_on_list: bool = True,
+def _display(
+    dest: str | None,
+    df: pd.DataFrame,
+    *,
+    index: bool = False,
+    title: str = "",
 ) -> None:
-    """Format and display."""
+    """Display the given dataframe in a readable format."""
 
-    def _titlecase(s) -> str:
-        arr: list[str] = s.split("_")
-        arr[0] = arr[0].title()
-        return " ".join(arr)
+    def df_apply(s) -> Any:
+        return s.astype(str)
 
-    row_label: str = ""
-    prefix_len: int = 4
-    prefix_char: str = " "
+    if title != "":
+        _output(
+            dest,
+            f"\n##{f" {title}" if not title.startswith("#") else title}\n\n",
+        )
 
-    try:
-        prefix: str = prefix_len * indent_level * prefix_char
-        if type(value) in (dict, list):
-            if type(value) is list:
-                row_label = f"{prefix}{label}"
-                if include_count_on_list:
-                    row_label += f" (count: {len(value)})"
-                row_label += ": "
-                click.echo(row_label)
-                prefix += prefix_len * prefix_char
-                if len(value) == 0:
-                    click.echo(f"{prefix}No details to show")
-                else:
-                    for val in value:
-                        click.echo(f"{prefix}{val}")
-            else:
-                row_label = f"{prefix}{label}: "
-                click.echo(row_label)
-                prefix += prefix_len * prefix_char
-                for item_label, item_value in value.items():
-                    _display_value(
-                        _titlecase(item_label).replace("_", " "),
-                        item_value,
-                        indent_level=1,
-                        include_count_on_list=include_count_on_list,
-                    )
-        else:
-            row_label = f"{prefix}{label}: "
-            click.echo(row_label, nl=False)
-            if type(value) is bool:
-                click.echo(display_bool_true if value else display_bool_false)
-            elif value is None:
-                click.echo(display_none)
-            else:
-                click.echo(value)
-    except Exception as exc:
-        click.echo(click.style(exc, fg="red"))
+    _output(
+        dest,
+        df.fillna("")
+        .apply(df_apply)
+        .to_markdown(
+            index=index,
+        ),
+    )
+
+    _output(dest, "\n")
+
+
+def _output(dest: str | None, contents: str) -> None:
+    """Write the contents to the specified location."""
+
+    click_dest: str = "-" if dest is None else dest
+    with click.open_file(click_dest, "at") as f:
+        f.write(contents)
+
+
+def _write_error(msg: Any) -> None:
+    """Output error to the screen."""
+
+    click.echo(click.style(msg, fg="red"), err=True)
 
 
 async def _get_device_details(
@@ -902,11 +1117,11 @@ async def _get_device_details(
                     device_qry, force_refresh=refresh
                 )
             except MeshDeviceNotFoundResponse as exc:
-                click.echo(click.style(f"{exc}: {exc.devices}", fg="red"), err=True)
-                return
+                _write_error(f"{exc}: {exc.devices}")
+                return None
             except Exception as exc:
-                click.echo(click.style(exc, fg="red"), err=True)
-                return
+                _write_error(exc)
+                return None
 
     return ret
 

--- a/pyvelop/decorators.py
+++ b/pyvelop/decorators.py
@@ -5,23 +5,30 @@ from __future__ import annotations
 
 import functools
 import logging
+from collections.abc import Callable
+from typing import Any, Concatenate, ParamSpec, TypeVar, cast
 
 from .exceptions import MeshNeedsInitialise
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 # endregion
 
 
-def deprecated(solution: str):
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def deprecated(solution: str) -> Callable[[F], F]:
     """Mark a method as deprecated."""
 
-    def deprecated_decorator(func):
+    def deprecated_decorator(func: F) -> F:
         """Decorate the function."""
 
-        @functools.wraps(func)
-        def deprecated_wrapper(self, *args, **kwargs):
+        def deprecated_wrapper(*args: Any, **kwargs: Any) -> Any:
             """Wrap for the original function."""
             logger = logging.getLogger(func.__module__)
-            log_formatter = getattr(self, "_log_formatter", None)
+            log_formatter = getattr(args[0], "_log_formatter", None)
             if log_formatter is not None:
                 logger.warning(
                     log_formatter.format(
@@ -32,22 +39,22 @@ def deprecated(solution: str):
                     solution,
                 )
 
-            return func(self, *args, **kwargs)
+            return func(*args, **kwargs)
 
-        return deprecated_wrapper
+        return cast(F, functools.wraps(func)(deprecated_wrapper))
 
     return deprecated_decorator
 
 
-def needs_initialise(func):
+def needs_initialise(
+    func: Callable[Concatenate[Any, P], R],
+) -> Callable[Concatenate[Any, P], R]:
     """Ensure that async_initialise has been executed."""
 
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> R:
         """Wrap the required function."""
         if not getattr(self, "_Mesh__initialise_executed", False):
             raise MeshNeedsInitialise from None
-        ret = func(self, *args, **kwargs)
-        return ret
+        return func(self, *args, **kwargs)
 
-    return wrapper
+    return cast(Callable[Concatenate[Any, P], R], functools.wraps(func)(wrapper))

--- a/pyvelop/exceptions.py
+++ b/pyvelop/exceptions.py
@@ -82,9 +82,17 @@ class MeshInvalidCredentials(MeshException):
 class MeshInvalidInput(MeshException):
     """Parameters passed to the API are in valid."""
 
+    def __init__(self, info: object | None = None) -> None:
+        """Initialise with optional info."""
+        super().__init__(str(info) if info is not None else "Invalid Input")
+
 
 class MeshInvalidOutput(MeshException):
     """Invalid information would be returned from the API."""
+
+    def __init__(self, info: object | None = None) -> None:
+        """Initialise with optional info."""
+        super().__init__(str(info) if info is not None else "Invalid Output")
 
 
 class MeshNeedsInitialise(MeshException):

--- a/pyvelop/jnap.py
+++ b/pyvelop/jnap.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import base64
 import json
 import logging
-from collections import defaultdict
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
@@ -37,7 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 _LOGGER_VERBOSE = logging.getLogger(f"{__name__}.verbose")
 
 
-def jnap_url(target) -> str:
+def jnap_url(target: str) -> str:
     """Return the URL that should be used for the request.
 
     :param target: the API host
@@ -108,12 +107,18 @@ class Actions(StrEnum):
 class Defaults:
     """Represents the default payloads required for requests."""
 
-    payloads = defaultdict(dict)
-    payloads[Actions.GET_SPEEDTEST_RESULTS] = {
-        "healthCheckModule": "SpeedTest",
-        "includeModuleResults": True,
-        "lastNumberOfResults": 10,
-    }
+    @staticmethod
+    def get(api_name: str) -> dict[str, Any]:
+        """Return the default payload for the given API name."""
+
+        if api_name == Actions.GET_SPEEDTEST_RESULTS.name:
+            return {
+                "healthCheckModule": "SpeedTest",
+                "includeModuleResults": True,
+                "lastNumberOfResults": 10,
+            }
+
+        return {}
 
 
 class Request:
@@ -124,7 +129,7 @@ class Request:
         action: str,
         password: str,
         target: str,
-        payload: list[dict] | dict | None = None,
+        payload: list[dict[str, Any]] | dict[str, Any] | None = None,
         raise_on_error: bool = True,
         session: aiohttp.ClientSession | None = None,
         username: str = "admin",
@@ -144,7 +149,7 @@ class Request:
             bytes(f"{username}:{password}", "utf-8")
         ).decode("ascii")
         self._log_formatter = Logger(prefix=f"{self.__class__.__name__}.")
-        self._payload: list[dict] | dict | None = payload
+        self._payload: list[dict[str, Any]] | dict[str, Any] | None = payload
         self._raise_on_error: bool = raise_on_error
         self._session: aiohttp.ClientSession = (
             session
@@ -230,7 +235,7 @@ class Request:
         return self._action
 
     @property
-    def payload(self) -> list[dict] | dict | None:
+    def payload(self) -> list[dict[str, Any]] | dict[str, Any] | None:
         """Return the payload used for the request.
 
         :return: list[dict] | dict | None containing the payload
@@ -277,7 +282,7 @@ class Response:
             if responses is None:
                 raise MeshException("error processing response")
 
-            err = None
+            err: MeshException | None = None
             for resp in responses:
                 err = None
                 if resp is None:
@@ -287,7 +292,7 @@ class Response:
                 elif resp.get(self.RESULT_KEY) == "_ErrorInvalidOutput":
                     err = MeshInvalidOutput(resp.get("error"))
                 elif resp.get(self.RESULT_KEY) == "_ErrorUnauthorized":
-                    err = MeshInvalidCredentials
+                    err = MeshInvalidCredentials()
                 elif resp.get(self.RESULT_KEY) == "_ErrorUnknownAction":
                     action = (
                         resp.get("error")
@@ -299,15 +304,15 @@ class Response:
                     resp.get(self.RESULT_KEY)
                     == "ErrorAutoChannelSelectionAlreadyInProgress"
                 ):
-                    err = MeshAlreadyInProgress
+                    err = MeshAlreadyInProgress()
                 elif resp.get(self.RESULT_KEY) == "ErrorCannotDeleteDevice":
-                    err = MeshCannotDeleteDevice
+                    err = MeshCannotDeleteDevice()
                 elif resp.get(self.RESULT_KEY) == "ErrorDeviceDBFailure":
                     err = MeshDeviceDbFailure(
                         resp.get(self.DATA_KEY_SINGLE, {}).get("ErrorInfo", "")
                     )
                 elif resp.get(self.RESULT_KEY) == "ErrorDeviceNotInMasterMode":
-                    err = MeshNodeNotPrimary
+                    err = MeshNodeNotPrimary()
                 elif resp.get(self.RESULT_KEY) == "ErrorInvalidWANSchedule":
                     err = MeshInvalidInput("Invalid WAN Schedule")
                 elif resp.get(self.RESULT_KEY) == "ErrorRulesOverlap":
@@ -329,7 +334,7 @@ class Response:
                     self._log_formatter.format("unknown error received: %s"),
                     self._data,
                 )
-                err = MeshBadResponse
+                err = MeshBadResponse()
 
             raise err
 
@@ -347,7 +352,7 @@ class Response:
         """Return the response data."""
 
         if self._data is None:
-            return
+            return None
 
         ret = (
             self._data.get(self.DATA_KEY_TRANSACTION)

--- a/pyvelop/logger.py
+++ b/pyvelop/logger.py
@@ -2,8 +2,24 @@
 
 # region #-- imports --#
 import inspect
+import logging
 
 # endregion
+
+
+def set_logging_format(
+    *, prefix: str = "", include_lineno: bool = False, include_func_name: bool = False
+) -> str:
+    """Set the format used by loggers."""
+
+    format: list[str] = logging.BASIC_FORMAT.split(":")
+    if include_lineno:
+        format.insert(-1, "%(lineno)d")
+    if include_func_name:
+        format.insert(-1, "%(funcName)s")
+    if prefix != "":
+        format[-1] = f"{prefix}{format[-1]}"
+    return ":".join(format)
 
 
 class Logger:

--- a/pyvelop/mesh.py
+++ b/pyvelop/mesh.py
@@ -10,7 +10,7 @@ import re
 import time
 import uuid
 from collections.abc import Coroutine
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import ClientSession
 
@@ -26,7 +26,6 @@ from .exceptions import (
     MeshInvalidCredentials,
     MeshInvalidInput,
 )
-from .logger import Logger
 from .mesh_entity import DeviceEntity, NodeEntity
 from .types import MeshDetails, NodeType
 
@@ -40,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 _LOGGER_VERBOSE = logging.getLogger(f"{__name__}.verbose")
 
 
-def _get_speedtest_state(speedtest_results=None) -> str:
+def _get_speedtest_state(speedtest_results: dict[str, Any] | None = None) -> str:
     """Process the Speedtest results to get a textual state."""
     if speedtest_results is None:
         speedtest_results = {}
@@ -132,9 +131,8 @@ class Mesh:
         :param session: session to use in for interacting with the Mesh
         :param username: username to use; default admin
         """
-        self._log_formatter = Logger()
 
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         self._mesh_attributes: dict[
             str, list[DeviceEntity] | list[NodeEntity] | api.JnapResponse
@@ -157,29 +155,32 @@ class Mesh:
         self.__passed_session: bool = isinstance(session, ClientSession)
 
         _LOGGER.debug(
-            self._log_formatter.format("Session was passed in: %s"),
-            "Yes" if self.__passed_session else "No",
+            "session was passed in: %s",
+            "yes" if self.__passed_session else "no",
         )
 
         _LOGGER.debug(
-            self._log_formatter.format("%s version: %s"),
+            "%s version: %s",
             __package__,
             __version__,
         )
         _LOGGER.debug(
-            self._log_formatter.format(
-                "Initialised mesh for %s with request timeout %ss"
-            ),
+            "initialised mesh for %s with request timeout %ss",
             self._mesh_details.host,
             self._mesh_details.request_timeout,
         )
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> Mesh:
         """Asynchronous enter magic method."""
         return self
 
-    async def __aexit__(self, exc_type, exc, traceback) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> None:
         """Asynchronous exit magic method."""
         await self.async_close()
 
@@ -196,9 +197,9 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER_VERBOSE.debug(self._log_formatter.format("entered"))
+        _LOGGER_VERBOSE.debug("entered")
         session = ClientSession(raise_for_status=True)
-        _LOGGER_VERBOSE.debug(self._log_formatter.format("exited"))
+        _LOGGER_VERBOSE.debug("exited")
         return session
 
     async def _async_make_request(
@@ -218,7 +219,7 @@ class Mesh:
 
         :return: tuple containing the request and response objects or raises an error if need be
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         if node_address is not None and action != api.Actions.REBOOT:
             raise MeshInvalidArguments
@@ -229,9 +230,7 @@ class Mesh:
         if (
             not self.__passed_session and self._mesh_details.session.closed
         ):  # session closed so recreate it
-            _LOGGER_VERBOSE.debug(
-                self._log_formatter.format("session was closed, reopening")
-            )
+            _LOGGER_VERBOSE.debug("session was closed, reopening")
             self._mesh_details.session = self.__create_session()
 
         req = api.Request(
@@ -248,7 +247,7 @@ class Mesh:
         except Exception as err:
             raise err from None
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
         return (req, req_resp)
 
     async def _async_gather_details(
@@ -258,9 +257,9 @@ class Mesh:
 
         :return: A dictionary containing the relevant details.
         """
-        _LOGGER.debug(self._log_formatter.format("entered, args: %s"), capabilities)
+        _LOGGER.debug("entered, args: %s", capabilities)
 
-        ret = {}
+        ret: dict[str, Any] = {}
         payload: list[dict[str, Any]] = []
 
         for capability in capabilities:
@@ -268,11 +267,11 @@ class Mesh:
             payload.append(
                 {
                     "action": jnap_action.value,
-                    "request": api.Defaults.payloads[jnap_action],
+                    "request": api.Defaults.get(jnap_action.name),
                 }
             )
 
-        responses: tuple[_ApiResponse] = await asyncio.gather(
+        responses: tuple[_ApiResponse, ...] = await asyncio.gather(
             self._async_make_request(api.Actions.TRANSACTION, payload=payload)
         )
 
@@ -282,7 +281,7 @@ class Mesh:
             try:
                 api_response: api.Response = api.Response(action=action, data=data)
             except MeshException as err:
-                _LOGGER.debug(self._log_formatter.format("%s"), err)
+                _LOGGER.debug("%s", err)
             else:
                 capability: MeshCapability = MeshCapability[api.Actions(action).name]
                 ret[capability.value] = api_response.data
@@ -292,7 +291,7 @@ class Mesh:
             if req.action == api.Actions.TRANSACTION:
                 if resp.data is not None and isinstance(resp.data, list):
                     for idx, action_response in enumerate(resp.data):
-                        if req.payload is not None:
+                        if isinstance(req.payload, list):
                             _set_raw_value(
                                 action=req.payload[idx].get("action", ""),
                                 data=action_response,
@@ -303,9 +302,10 @@ class Mesh:
 
         # region #-- handle mesh entities --#
         mesh_entities: list[DeviceEntity | NodeEntity] = []
-        discovered_mesh_entities: list[dict[str, Any]] = ret.get(
-            MeshCapability.GET_DEVICES.value, {}
-        ).get("devices", [])
+        discovered_mesh_entities: list[dict[str, Any]] = cast(
+            list[dict[str, Any]],
+            ret.get(MeshCapability.GET_DEVICES.value, {}).get("devices", []),
+        )
         # region #-- build the properties for the mesh entity types --#
         for entity in discovered_mesh_entities:
             entity_data: dict[str, Any] = {}
@@ -313,7 +313,7 @@ class Mesh:
             entity_data.update(entity)
             if "nodeType" not in entity:
                 # region #-- process MAC based information --#
-                dev_pc_schedule: list = []
+                dev_pc_schedule: list[dict[str, Any]] = []
                 dev_adapter_macs: list[str] = [
                     dev_adapter.get("macAddress")
                     for dev_adapter in entity.get("knownInterfaces", [])
@@ -441,7 +441,7 @@ class Mesh:
         ret[_ATTR_PROCESSED_DEVICES] = mesh_entities or []
         # endregion
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
         return ret
 
     async def _async_set_device_property(
@@ -455,9 +455,7 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER.debug(
-            self._log_formatter.format("entered, name: %s, value: %s"), name, value
-        )
+        _LOGGER.debug("entered, name: %s, value: %s", name, value)
 
         try:
             await self._async_make_request(
@@ -479,7 +477,7 @@ class Mesh:
         except Exception as err:
             _LOGGER.error(err)
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     # endregion
 
@@ -491,11 +489,11 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
         await self._async_make_request(
             action=api.Actions.UPDATE_FIRMWARE, payload={"onlyCheck": True}
         )
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_close(self) -> None:
         """Close the session to the mesh.
@@ -503,9 +501,9 @@ class Mesh:
         :return: None
         """
         if not self.__passed_session:
-            _LOGGER.debug(self._log_formatter.format("entered"))
+            _LOGGER.debug("entered")
             await self._mesh_details.session.close()
-            _LOGGER.debug(self._log_formatter.format("exited"))
+            _LOGGER.debug("exited")
 
     async def async_detect_capabilities(self) -> list[MeshCapability]:
         """Attempt to detect the capabilities of the Mesh.
@@ -513,13 +511,13 @@ class Mesh:
         :return: list of capabilities for the mesh.
         """
         ret: list[MeshCapability] = []
-        requests: list[Coroutine] = []
+        requests: list[Coroutine[Any, Any, _ApiResponse]] = []
         for qry in MeshCapability:
             action_name: str = qry.name
             requests.append(
                 self._async_make_request(
                     action=getattr(api.Actions, action_name),
-                    payload=api.Defaults.payloads[getattr(api.Actions, action_name)],
+                    payload=api.Defaults.get(action_name),
                     raise_on_error=False,
                 )
             )
@@ -544,12 +542,12 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         self._mesh_attributes = await self._async_gather_details(
             self._mesh_capabilities
         )
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_get_channel_scan_info(self) -> dict[str, Any] | None:
         """Get the current state of the channel scan.
@@ -576,7 +574,7 @@ class Mesh:
 
         :return: List of device objects
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         all_devices: list[DeviceEntity] = []
         ret: list[DeviceEntity] = []
@@ -659,7 +657,7 @@ class Mesh:
 
         ret = sorted(ret, key=lambda device: device.name)
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
         return ret
 
     async def async_get_speedtest_results(
@@ -673,17 +671,17 @@ class Mesh:
 
         :return: List of dictionaries containing the result details
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         payload = {
-            **api.Defaults.payloads[api.Actions.GET_SPEEDTEST_RESULTS],
+            **api.Defaults.get(api.Actions.GET_SPEEDTEST_RESULTS),
             "lastNumberOfResults": count,
         }
         _, resp = await self._async_make_request(
             action=api.Actions.GET_SPEEDTEST_RESULTS, payload=payload
         )
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
         ret = []
         if resp.data is not None and not isinstance(resp.data, list):
             speedtest_results = resp.data.get("healthCheckResults", [])
@@ -701,7 +699,7 @@ class Mesh:
 
         :return: A string containing the stage
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         resp = await self._async_gather_details([MeshCapability.GET_SPEEDTEST_STATUS])
         ret = _get_speedtest_state(
@@ -710,7 +708,7 @@ class Mesh:
             )
         )
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
         return ret
 
     async def async_get_update_state(self) -> bool:
@@ -718,7 +716,7 @@ class Mesh:
 
         :return: True if still running, False if not
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         resp = await self._async_gather_details(
             [MeshCapability.GET_UPDATE_FIRMWARE_STATE]
@@ -731,7 +729,7 @@ class Mesh:
 
         ret: bool = any(all_states)
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
         return ret
 
     async def async_get_upnp_state(self) -> dict[str, bool]:
@@ -740,13 +738,15 @@ class Mesh:
         :return: dictionary containing information about the state of UPnP functionality
         """
 
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         resp = await self._async_gather_details([MeshCapability.GET_UPNP_SETTINGS])
 
-        ret = resp.get(MeshCapability.GET_UPNP_SETTINGS.value, {})
+        ret = cast(
+            dict[str, bool], resp.get(MeshCapability.GET_UPNP_SETTINGS.value, {})
+        )
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
         return ret
 
     async def async_initialise(self) -> None:
@@ -777,7 +777,7 @@ class Mesh:
     async def async_reboot_mesh(self) -> None:
         """Reboot the mesh."""
 
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
         found_node: NodeEntity | None = next(
             (node for node in self.nodes if node.type == NodeType.PRIMARY),
             None,
@@ -788,7 +788,7 @@ class Mesh:
 
         await found_node.async_reboot(True)
 
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
     async def async_set_guest_wifi_state(self, state: bool) -> None:
         """Set the state of the guest Wi-Fi.
@@ -801,7 +801,7 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER.debug(self._log_formatter.format("entered, state: %s"), state)
+        _LOGGER.debug("entered, state: %s", state)
 
         # get the current radio settings from the API; they may have changed
         resp = await self._async_gather_details([MeshCapability.GET_GUEST_NETWORK_INFO])
@@ -815,7 +815,7 @@ class Mesh:
             action=api.Actions.SET_GUEST_NETWORK, payload=payload
         )
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_set_homekit_state(self, state: bool) -> None:
         """Set the state of the HomeKit feature.
@@ -824,11 +824,11 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER.debug(self._log_formatter.format("entered, state: %s"), state)
+        _LOGGER.debug("entered, state: %s", state)
         await self._async_make_request(
             action=api.Actions.SET_HOMEKIT_SETTINGS, payload={"isEnabled": state}
         )
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_set_parental_control_state(self, state: bool) -> None:
         """Set the state of the Parental Control feature. Rules are left intact.
@@ -837,7 +837,7 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER.debug(self._log_formatter.format("entered, state: %s"), state)
+        _LOGGER.debug("entered, state: %s", state)
         # get the current rules from the API because they may be different
         resp = await self._async_gather_details(
             [MeshCapability.GET_PARENTAL_CONTROL_INFO]
@@ -852,7 +852,7 @@ class Mesh:
             action=api.Actions.SET_PARENTAL_CONTROL_INFO, payload=payload
         )
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_set_upnp_settings(
         self, enabled: bool, allow_change_settings: bool, allow_disable_internet: bool
@@ -866,9 +866,7 @@ class Mesh:
         :return: None
         """
         _LOGGER.debug(
-            self._log_formatter.format(
-                "entered, enabled: %s, allow_change_settings: %s, allow_disable_internet: %s"
-            ),
+            "entered, enabled: %s, allow_change_settings: %s, allow_disable_internet: %s",
             enabled,
             allow_change_settings,
             allow_disable_internet,
@@ -881,7 +879,7 @@ class Mesh:
         await self._async_make_request(
             action=api.Actions.SET_UPNP_SETTINGS, payload=payload
         )
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_set_wps_state(self, state: bool) -> None:
         """Set the state of the WPS feature.
@@ -890,35 +888,30 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER.debug(self._log_formatter.format("entered, state: %s"), state)
+        _LOGGER.debug("entered, state: %s", state)
         await self._async_make_request(
             action=api.Actions.SET_WPS_SERVER_SETTINGS, payload={"enabled": state}
         )
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_start_channel_scan(self) -> None:
         """Start a channel scan on the mesh.
 
         :return: None
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         try:
             await self._async_make_request(action=api.Actions.START_CHANNEL_SCAN)
         except MeshAlreadyInProgress as err:
-            _LOGGER.debug(
-                self._log_formatter.format("%s"),
-                err,
-            )
+            _LOGGER.debug(err)
         except MeshInvalidInput as err:
             _LOGGER.warning(
-                self._log_formatter.format(
-                    "%s - are you sure the functionality is available"
-                ),
+                "%s - are you sure the functionality is available",
                 err,
             )
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_start_speedtest(self) -> None:
         """Instruct the mesh to carry out a Speedtest.
@@ -928,21 +921,21 @@ class Mesh:
 
         :return: None
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         payload = {"runHealthCheckModule": "SpeedTest"}
         await self._async_make_request(
             action=api.Actions.START_SPEEDTEST, payload=payload
         )
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
 
     async def async_test_credentials(self) -> bool:
         """Check the provided credentials are valid.
 
         :return: True if valid, False if not
         """
-        _LOGGER.debug(self._log_formatter.format("entered"))
+        _LOGGER.debug("entered")
 
         ret: bool = False
         try:
@@ -957,7 +950,7 @@ class Mesh:
             _LOGGER.error(err)
             raise
 
-        _LOGGER.debug(self._log_formatter.format("exited"))
+        _LOGGER.debug("exited")
         return ret
 
     # endregion
@@ -1000,11 +993,14 @@ class Mesh:
         :return: True if enabled, False otherwise.
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_TOPOLOGY_OPTIMISATION_SETTINGS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(
+                MeshCapability.GET_TOPOLOGY_OPTIMISATION_SETTINGS.value, {}
+            ),
         )
 
-        return attr.get("isClientSteeringEnabled")
+        return cast(bool | None, attr.get("isClientSteeringEnabled"))
 
     @property
     def connected_node(self) -> str:
@@ -1040,11 +1036,12 @@ class Mesh:
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_LAN_SETTINGS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_LAN_SETTINGS.value, {}),
         )
 
-        return attr.get("isDHCPEnabled")
+        return cast(bool | None, attr.get("isDHCPEnabled"))
 
     @property
     @needs_initialise
@@ -1056,8 +1053,9 @@ class Mesh:
         ret: list[dict[str, str]] = []
         temp_dict: dict[str, str] = {}
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_LAN_SETTINGS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_LAN_SETTINGS.value, {}),
         )
 
         for reservation in attr.get("dhcpSettings", {}).get("reservations", []):
@@ -1118,11 +1116,12 @@ class Mesh:
         :return: True if enabled
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_GUEST_NETWORK_INFO.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_GUEST_NETWORK_INFO.value, {}),
         )
 
-        return attr.get("isGuestNetworkEnabled")
+        return cast(bool | None, attr.get("isGuestNetworkEnabled"))
 
     @property
     @needs_initialise
@@ -1132,16 +1131,18 @@ class Mesh:
         :return: A list of dictionaries containing the SSID and band for the networks
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_GUEST_NETWORK_INFO.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_GUEST_NETWORK_INFO.value, {}),
         )
+        radios = cast(list[dict[str, Any]], attr.get("radios", []))
 
         ret = [
             {
-                "ssid": radio.get("guestSSID"),
-                "band": radio.get("radioID").split("_")[-1],
+                "ssid": cast(str, radio.get("guestSSID")),
+                "band": cast(str, radio.get("radioID", "")).split("_")[-1],
             }
-            for _, radio in enumerate(attr.get("radios", []))
+            for radio in radios
         ]
         return ret
 
@@ -1153,11 +1154,12 @@ class Mesh:
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_HOMEKIT_SETTINGS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_HOMEKIT_SETTINGS.value, {}),
         )
 
-        return attr.get("isEnabled")
+        return cast(bool | None, attr.get("isEnabled"))
 
     @property
     @needs_initialise
@@ -1167,11 +1169,12 @@ class Mesh:
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_HOMEKIT_SETTINGS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_HOMEKIT_SETTINGS.value, {}),
         )
 
-        return attr.get("isPaired")
+        return cast(bool | None, attr.get("isPaired"))
 
     @property
     @needs_initialise
@@ -1181,11 +1184,12 @@ class Mesh:
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_CHANNEL_SCAN_STATUS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_CHANNEL_SCAN_STATUS.value, {}),
         )
 
-        return attr.get("isRunning")
+        return cast(bool | None, attr.get("isRunning"))
 
     @property
     @needs_initialise
@@ -1199,8 +1203,9 @@ class Mesh:
 
         ret: _SpeedtestResult | None = None
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_SPEEDTEST_RESULTS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_SPEEDTEST_RESULTS.value, {}),
         )
         results: list[_SpeedtestResult] = _process_speedtest_results(
             attr.get("healthCheckResults", []),
@@ -1220,11 +1225,14 @@ class Mesh:
         :return: list of MAC addresses
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_MAC_FILTERING_SETTINGS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(
+                MeshCapability.GET_MAC_FILTERING_SETTINGS.value, {}
+            ),
         )
 
-        return attr.get("macAddresses", [])
+        return cast(list[str], attr.get("macAddresses", []))
 
     @property
     @needs_initialise
@@ -1234,11 +1242,14 @@ class Mesh:
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_MAC_FILTERING_SETTINGS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(
+                MeshCapability.GET_MAC_FILTERING_SETTINGS.value, {}
+            ),
         )
 
-        return attr.get("macFilterMode", "").lower() != "disabled"
+        return cast(str, attr.get("macFilterMode", "")).lower() != "disabled"
 
     @property
     @needs_initialise
@@ -1248,11 +1259,14 @@ class Mesh:
         :return: string containing the filtering mode
         """
         if self.mac_filtering_enabled:
-            attr: api.JnapResponse | Any = self._mesh_attributes.get(
-                MeshCapability.GET_MAC_FILTERING_SETTINGS.value, {}
+            attr = cast(
+                dict[str, Any],
+                self._mesh_attributes.get(
+                    MeshCapability.GET_MAC_FILTERING_SETTINGS.value, {}
+                ),
             )
 
-            return attr.get("macFilterMode", "").lower()
+            return cast(str, attr.get("macFilterMode", "")).lower()
 
         return None
 
@@ -1334,16 +1348,17 @@ class Mesh:
 
     @property
     @needs_initialise
-    def storage_available(self) -> list:
+    def storage_available(self) -> list[dict[str, Any]]:
         """Get available shared partitions.
 
         :return: List of the available storage devices and their properties
         """
-        ret: list = []
+        ret: list[dict[str, Any]] = []
         node: NodeEntity | None
-        device: dict
-        storage_available: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_STORAGE_PARTITIONS.value, {}
+        device: dict[str, Any]
+        storage_available = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(MeshCapability.GET_STORAGE_PARTITIONS.value, {}),
         )
 
         for storage_node in storage_available.get("storageNodes", []):
@@ -1388,17 +1403,23 @@ class Mesh:
 
     @property
     @needs_initialise
-    def storage_settings(self) -> dict:
+    def storage_settings(self) -> dict[str, bool | None]:
         """Get the settings for shared partitions.
 
         :return: dictionary of the storage settings
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_STORAGE_SMB_SERVER.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(
+                MeshCapability.GET_STORAGE_SMB_SERVER.value,
+                {},
+            ),
         )
 
-        return {"anonymous_access": attr.get("isAnonymousAccessEnabled")}
+        return {
+            "anonymous_access": cast(bool | None, attr.get("isAnonymousAccessEnabled"))
+        }
 
     @property
     def timeout(self) -> float:
@@ -1418,9 +1439,7 @@ class Mesh:
         :return: None
         """
 
-        _LOGGER.debug(
-            self._log_formatter.format("setting request timeout to: %ss"), value
-        )
+        _LOGGER.debug("setting request timeout to: %ss", value)
         self._mesh_details.request_timeout = value
 
     @property
@@ -1467,7 +1486,7 @@ class Mesh:
 
     @property
     @needs_initialise
-    def wan_dns(self) -> list:
+    def wan_dns(self) -> list[str]:
         """Get the WAN DNS servers.
 
         :return: A list containing the IP addresses of the WAN DNS servers
@@ -1478,8 +1497,8 @@ class Mesh:
         )
 
         ret = [
-            val
-            for key, val in attr.get("wanConnection", {}).items()
+            cast(str, val)
+            for key, val in cast(dict[str, Any], attr.get("wanConnection", {})).items()
             if key.startswith("dnsServer")
         ]
 
@@ -1493,10 +1512,17 @@ class Mesh:
         :return: A string containing the IP address for the WAN
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_WAN_INFO.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(
+                MeshCapability.GET_WAN_INFO.value,
+                {},
+            ),
         )
-        return attr.get("wanConnection", {}).get("ipAddress")
+        return cast(
+            str | None,
+            cast(dict[str, Any], attr.get("wanConnection", {})).get("ipAddress"),
+        )
 
     @property
     @needs_initialise
@@ -1506,11 +1532,15 @@ class Mesh:
         :return: A string containing the MAC address for the WAN adapter
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_WAN_INFO.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(
+                MeshCapability.GET_WAN_INFO.value,
+                {},
+            ),
         )
 
-        return attr.get("macAddress", "")
+        return cast(str, attr.get("macAddress", ""))
 
     @property
     @needs_initialise
@@ -1520,11 +1550,15 @@ class Mesh:
         :return: True if connected, False if not
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_WAN_INFO.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(
+                MeshCapability.GET_WAN_INFO.value,
+                {},
+            ),
         )
 
-        return attr.get("wanStatus", "").lower() == "connected"
+        return cast(str, attr.get("wanStatus", "")).lower() == "connected"
 
     @property
     @needs_initialise
@@ -1534,10 +1568,14 @@ class Mesh:
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(
-            MeshCapability.GET_WPS_SERVER_SETTINGS.value, {}
+        attr = cast(
+            dict[str, Any],
+            self._mesh_attributes.get(
+                MeshCapability.GET_WPS_SERVER_SETTINGS.value,
+                {},
+            ),
         )
 
-        return attr.get("enabled", False)
+        return cast(bool, attr.get("enabled", False))
 
     # endregion

--- a/pyvelop/mesh_entity.py
+++ b/pyvelop/mesh_entity.py
@@ -7,8 +7,8 @@ import contextlib
 import datetime
 import logging
 from collections import namedtuple
-from collections.abc import Callable
-from typing import Any, TypeVar, final
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar, cast, final
 
 from . import jnap as api
 from .const import (
@@ -59,17 +59,16 @@ class ParentalControl:
         for day, sched in schedule.items():
             ret[day.lower()] = []
             idx: int = 0
-            while idx < __class__.BINARY_LENGTH:
+            while idx < ParentalControl.BINARY_LENGTH:
                 block_start: int | None = (
                     sched.index(ParentalControlActionType.BLOCKED.value, idx)
                     if sched is not None
                     and ParentalControlActionType.BLOCKED.value in sched[idx + 1 :]
                     else None
                 )
-                block_end: int | None = None
                 if block_start is None:
                     break
-                block_end = (
+                block_end: int | None = (
                     sched.index(
                         ParentalControlActionType.UNBLOCKED.value, block_start + 1
                     )
@@ -96,7 +95,7 @@ class ParentalControl:
                 if block_end is not None:
                     idx = block_end + 1
                 else:
-                    idx = __class__.BINARY_LENGTH
+                    idx = ParentalControl.BINARY_LENGTH
 
         return ret
 
@@ -105,15 +104,15 @@ class ParentalControl:
     def backup_to_binary(schedule: str) -> dict[str, str]:
         """Decode the schedule for restoring to the device."""
         ret: dict[str, str] = {}
-        decoded = schedule and base64.b64decode(schedule)
+        decoded = base64.b64decode(schedule) if schedule else b""
         sorted_schedule: str = ""
         for chunk in decoded:
             sorted_schedule += f"{int(chunk):08b}"
 
         for daily_schedule in range(0, len(list(Weekdays))):
-            start = daily_schedule * __class__.BINARY_LENGTH
+            start = daily_schedule * ParentalControl.BINARY_LENGTH
             ret[Weekdays(daily_schedule).name] = sorted_schedule[
-                start : start + __class__.BINARY_LENGTH
+                start : start + ParentalControl.BINARY_LENGTH
             ]
 
         return ret
@@ -135,7 +134,10 @@ class ParentalControl:
         for chunk in sorted_chunks:
             chunk_chars.append(int(chunk, base=2))
 
-        ret = chunk_chars and base64.b64encode(chunk_chars).decode()
+        if chunk_chars:
+            ret = base64.b64encode(chunk_chars).decode()
+        else:
+            ret = ""
         return ret
 
     @staticmethod
@@ -148,13 +150,13 @@ class ParentalControl:
         """Generate a rule dictionary that can be passed to the API."""
         ret: dict[str, Any] = {
             "blockedURLs": blocked_urls if blocked_urls is not None else [],
-            "description": __class__.DEFAULT_DESCRIPTION,
+            "description": ParentalControl.DEFAULT_DESCRIPTION,
             "isEnabled": True,
             "macAddresses": [mac_address],
             "wanSchedule": (
                 schedule
                 if not schedule_to_binary
-                else __class__.human_readable_to_binary(schedule)
+                else ParentalControl.human_readable_to_binary(schedule)
             ),
         }
         return ret
@@ -173,11 +175,11 @@ class ParentalControl:
             if len(to_process) > len(Weekdays):
                 raise ValueError("Too many arguments")
 
-        ret: str | dict[str, str] = {}
+        ret_dict: dict[str, str] = {}
         for day, schedule in to_process.items():
             default_binary = [
                 ParentalControlActionType.UNBLOCKED.value
-            ] * __class__.BINARY_LENGTH
+            ] * ParentalControl.BINARY_LENGTH
             if schedule is not None:
                 time_schedules: list[str] = schedule.split(",")
                 TimeBlock = namedtuple("TimeBlock", ["start", "end"])
@@ -193,13 +195,13 @@ class ParentalControl:
                         and time_block.start.minute == 0
                     ):
                         offset_start = 0
-                        offset_end = __class__.BINARY_LENGTH
+                        offset_end = ParentalControl.BINARY_LENGTH
                     elif (  # time wrapping
                         time_block.end < time_block.start
                         and str(time_block.end.time()) != "00:00:00"
                     ):
                         offset_start = 0
-                        offset_end = __class__.BINARY_LENGTH
+                        offset_end = ParentalControl.BINARY_LENGTH
                     else:  # normal time
                         offset_start = time_block.start.hour * 2 + (
                             1 if time_block.start.minute >= 30 else 0
@@ -220,12 +222,12 @@ class ParentalControl:
                     ):
                         break
 
-            ret[day] = "".join(default_binary)
+            ret_dict[day] = "".join(default_binary)
 
         if isinstance(to_encode, str):
-            ret = ret[fake_day]
+            return ret_dict[fake_day]
 
-        return ret
+        return ret_dict
 
     @staticmethod
     def binary_to_human_readable(
@@ -249,12 +251,14 @@ class ParentalControl:
     @property
     def blocked_urls(self) -> list[str]:
         """Return blocked URLs."""
-        return self._rule.get("blockedURLs", [])
+        return cast(list[str], self._rule.get("blockedURLs", []))
 
     @property
     def description(self) -> str:
         """Return the rule description."""
-        return self._rule.get("description", __class__.DEFAULT_DESCRIPTION)
+        return cast(
+            str, self._rule.get("description", ParentalControl.DEFAULT_DESCRIPTION)
+        )
 
     @property
     def human_readable(self) -> dict[str, list[str]]:
@@ -264,17 +268,17 @@ class ParentalControl:
     @property
     def is_enabled(self) -> bool:
         """Return whether the rule is enabled or not."""
-        return self._rule.get("isEnabled", True)
+        return cast(bool, self._rule.get("isEnabled", True))
 
     @property
     def is_paused(self) -> bool:
         """Return whether the rule is all blocking."""
-        return self.schedule == __class__.ALL_PAUSED_SCHEDULE()
+        return self.schedule == ParentalControl.ALL_PAUSED_SCHEDULE()
 
     @property
     def mac_addresses(self) -> list[str]:
         """Return the MAC addresses the rule is for."""
-        return self._rule.get("macAddresses", [])
+        return cast(list[str], self._rule.get("macAddresses", []))
 
     @final
     @property
@@ -291,7 +295,7 @@ class ParentalControl:
     @property
     def schedule(self) -> dict[str, str]:
         """Return the current internet access schedule used in the rule."""
-        return self._rule.get("wanSchedule", {})
+        return cast(dict[str, str], self._rule.get("wanSchedule", {}))
 
     # endregion
 
@@ -321,7 +325,7 @@ class MeshEntity:
         ret: str | None = None
 
         user_properties: list[dict[str, Any]] = self._data.get("properties", [])
-        user_prop: list[dict[str, Any]] | str = [
+        user_prop: list[dict[str, Any]] = [
             prop for prop in user_properties if prop.get("name") == property_name.value
         ]
         if user_prop:
@@ -463,7 +467,7 @@ class MeshEntity:
 
         :return: The parent node name or None if no node has been identified.
         """
-        return self._data.get("parent_name")
+        return cast(str | None, self._data.get("parent_name"))
 
     @property
     def results_time(self) -> str | None:
@@ -471,7 +475,7 @@ class MeshEntity:
 
         :return: The time the scan was executed
         """
-        return self._data.get("results_time")
+        return cast(str | None, self._data.get("results_time"))
 
     @property
     def status(self) -> bool:
@@ -496,7 +500,7 @@ class MeshEntity:
     @property
     def unique_id(self) -> str | None:
         """Return the unique id of the entity."""
-        return self._data.get("deviceID")
+        return cast(str | None, self._data.get("deviceID"))
 
 
 MeshEntityType = TypeVar("MeshEntityType", bound=MeshEntity)
@@ -837,7 +841,7 @@ class DeviceEntity(MeshEntity):
             )
         )
 
-        requests: list = [
+        requests: list[Awaitable[api.Response]] = [
             self._async_api_request(
                 api.Actions.SET_PARENTAL_CONTROL_INFO,
                 {
@@ -893,7 +897,7 @@ class DeviceEntity(MeshEntity):
 
         :return: Device description as per the mesh
         """
-        return self._data.get("model", {}).get("description", None)
+        return cast(str | None, self._data.get("model", {}).get("description", None))
 
     @property
     def manufacturer(self) -> str | None:
@@ -941,21 +945,20 @@ class DeviceEntity(MeshEntity):
 
         :return: dictionary containing the parental controls for the device.
         """
-        ret: dict = {}
-        if self._data.get("parental_controls"):
-            for rule in self._data.get("parental_controls", {}):
-                pc_details: ParentalControl = ParentalControl(rule)
-                ret = {
-                    "blocked_internet_access": pc_details.human_readable,
-                    "blocked_sites": pc_details.blocked_urls,
-                }
+        ret: dict[str, Any] = {}
+        for rule in self._data.get("parental_controls", []):
+            pc_details: ParentalControl = ParentalControl(rule)
+            ret = {
+                "blocked_internet_access": pc_details.human_readable,
+                "blocked_sites": pc_details.blocked_urls,
+            }
 
         return ret
 
     @property
     def serial(self) -> str | None:
         """Get the serial number."""
-        return self._data.get("unit", {}).get("serialNumber", None)
+        return cast(str | None, self._data.get("unit", {}).get("serialNumber", None))
 
 
 class NodeEntity(MeshEntity):
@@ -1091,7 +1094,7 @@ class NodeEntity(MeshEntity):
 
         :return: A string containing the hardware version
         """
-        return self._data.get("model", {}).get("hardwareVersion")
+        return cast(str | None, self._data.get("model", {}).get("hardwareVersion"))
 
     @property
     def last_update_check(self) -> str | None:
@@ -1099,7 +1102,10 @@ class NodeEntity(MeshEntity):
 
         :return: String containing the last update time as per the API
         """
-        ret = self._data.get("firmware_updates", {}).get("lastSuccessfulCheckTime")
+        ret = cast(
+            str | None,
+            self._data.get("firmware_updates", {}).get("lastSuccessfulCheckTime"),
+        )
         return ret
 
     @property
@@ -1108,7 +1114,7 @@ class NodeEntity(MeshEntity):
 
         :return: String containing the name of the manufacturer
         """
-        return self._data.get("model", {}).get("manufacturer")
+        return cast(str | None, self._data.get("model", {}).get("manufacturer"))
 
     @property
     def model(self) -> str | None:
@@ -1116,7 +1122,7 @@ class NodeEntity(MeshEntity):
 
         :return: A string containing the model
         """
-        return self._data.get("model", {}).get("modelNumber")
+        return cast(str | None, self._data.get("model", {}).get("modelNumber"))
 
     @property
     def parent_ip(self) -> str | None:
@@ -1124,7 +1130,7 @@ class NodeEntity(MeshEntity):
 
         :return: The IP of the parent node or None if no node has been identified.
         """
-        return self._data.get("backhaul", {}).get("parentIPAddress")
+        return cast(str | None, self._data.get("backhaul", {}).get("parentIPAddress"))
 
     @property
     def serial(self) -> str | None:
@@ -1132,7 +1138,7 @@ class NodeEntity(MeshEntity):
 
         :return: A string containing the serial number
         """
-        return self._data.get("unit", {}).get("serialNumber")
+        return cast(str | None, self._data.get("unit", {}).get("serialNumber"))
 
     @property
     def type(self) -> NodeType:


### PR DESCRIPTION
CoPilot was used to fix up all the type hints available in the package.
The CLI has been overhauled to allow output to a file as markdown.  If no file path is provided the output is to the screen.