### PR TITLE
fix: Passing of guest radio info when setting guest network state

### DIFF
--- a/pyvelop/mesh.py
+++ b/pyvelop/mesh.py
@@ -805,7 +805,13 @@ class Mesh:
 
         # get the current radio settings from the API; they may have changed
         resp = await self._async_gather_details([MeshCapability.GET_GUEST_NETWORK_INFO])
-        radios = resp.get("radios", [])
+        radios = resp.get(
+            MeshCapability.GET_GUEST_NETWORK_INFO.value, {}
+        ).get("radios", [])
+        
+        for radio_details in radios:
+            radio_details["isEnabled"] = state
+            radio_details["broadcastGuestSSID"] = state
 
         payload = {
             "isGuestNetworkEnabled": state,


### PR DESCRIPTION
Enabling the guest network on my MR7500 only works if I have previously turned on the guest network via the Velop settings UI sometime after the last reboot. When enabling the guest network after having rebooted or powered on the MR7500, the radios for the guest network are never activated (though the reported guest network status does change to "Enabled").

I noticed in `async_set_guest_wifi_state` that the `radios` payload being sent was always an empty list, despite being present when calling `guest_wifi_details`. The issue was that the list of radios being retrieved from `_async_gather_details([MeshCapability.GET_GUEST_NETWORK_INFO])` is nested inside a `guest_network_info` dictionary that was not accounted for during retrieval.

Two properties in the `radios` payload (`isEnabled` and `broadcastGuestSSID`) also have to be adjusted to match the desired guest network state. The guest radios are never activated/deactivated if `isEnabled` isn't adjusted. `broadcastGuestSSID` has to be set to `True` when enabling the guest network in order for the SSID to be advertised.

With these changes, setting the guest network state now always works as expected regardless of having previously turned on the guest network via the Velop settings UI after the last reboot.