### PR TITLE
fix: derive device parent from wireless connection data

### DIFF
--- a/pyvelop/mesh.py
+++ b/pyvelop/mesh.py
@@ -518,6 +518,7 @@ class Mesh:
                             ),
                             None,
                         )
+            # parent is still missing, see if we can find it for a wireless client
             if parent_name is None and wireless_parent_id is not None:
                 parent_name = next(
                     (

--- a/pyvelop/mesh.py
+++ b/pyvelop/mesh.py
@@ -395,6 +395,7 @@ class Mesh:
         # region #-- build the properties for the mesh entity types --#
         for entity in discovered_mesh_entities:
             entity_data: dict[str, Any] = {}
+            wireless_parent_id: str | None = None
             # stamp the gather time into each entity
             entity_data["results_time"] = self._last_gather_details.get("gather_end")
             entity_data.update(entity)
@@ -432,6 +433,7 @@ class Mesh:
                         for connection in conn_details.get("connections", {}):
                             if dev_mac == connection.get("macAddress"):
                                 entity_data["connection_details"] = connection
+                                wireless_parent_id = conn_details.get("deviceID")
                                 break
                     # endregion
                 # endregion
@@ -516,6 +518,15 @@ class Mesh:
                             ),
                             None,
                         )
+            if parent_name is None and wireless_parent_id is not None:
+                parent_name = next(
+                    (
+                        NodeEntity(e, self._mesh_details).name
+                        for e in discovered_mesh_entities
+                        if e.get("deviceID") == wireless_parent_id
+                    ),
+                    None,
+                )
             entity_data["parent_name"] = parent_name
             # endregion
 

--- a/pyvelop/mesh.py
+++ b/pyvelop/mesh.py
@@ -395,7 +395,7 @@ class Mesh:
         # region #-- build the properties for the mesh entity types --#
         for entity in discovered_mesh_entities:
             entity_data: dict[str, Any] = {}
-            wireless_parent_id: str | None = None
+            wireless_parent_id: str | None = None  # used to track parent id in case it is missing
             # stamp the gather time into each entity
             entity_data["results_time"] = self._last_gather_details.get("gather_end")
             entity_data.update(entity)


### PR DESCRIPTION
## Summary

Use `GetNetworkConnections.nodeWirelessConnections` as a fallback for resolving a device's parent node when `GetDevices` omits `connections[].parentDeviceID`.

## Problem

`pyvelop` already matches a device MAC against `nodeWirelessConnections` to retain wireless details such as RSSI. The enclosing wireless-node `deviceID` is currently discarded, however, so `DeviceEntity.parent_name` remains unknown when `GetDevices` does not provide `parentDeviceID`.

## Change

- Retain the enclosing wireless node's `deviceID` during the existing MAC match.
- Preserve the existing `parentDeviceID` resolution as the first choice.
- Use the wireless node ID only when the existing resolution does not identify a parent.
- Preserve existing node backhaul and IP-based parent resolution behavior.

This intentionally does not change online-status handling, connected-device generation, timestamp selection, or MAC-matching behavior.

## Validation

- Reproduced the missing-parent behavior before the change.
- Verified the wireless-node fallback with sanitized fixture data.
- Verified that an existing valid `parentDeviceID` remains authoritative.
- Verified fallback when an explicit parent ID cannot be resolved.
- Verified unknown wireless-node handling and existing node backhaul resolution.
- Passed Ruff lint and formatting checks.
- Passed Python compilation.
- Successfully built the source distribution and wheel.

## AI assistance

This change and its accompanying description were prepared with assistance from OpenAI Codex. The contributor reviewed the resulting diff and validated its behavior before submission.
