### PR TITLE
fix: preserve best-effort device parent resolution

### DIFF
--- a/pyvelop/mesh.py
+++ b/pyvelop/mesh.py
@@ -467,7 +467,7 @@ class Mesh:
                                 parent_node = n
                                 break
                 # endregion
-            elif isinstance(node_or_device, DeviceEntity) and node_or_device.status:
+            elif isinstance(node_or_device, DeviceEntity):
                 # region #-- check in the connections list for a parent ID --#
                 parent_node = next(
                     (conn.get("parentDeviceID") for conn in node_or_device.raw_details.get("connections", [])), None
@@ -475,16 +475,14 @@ class Mesh:
                 # endregion
                 if not parent_node:
                     # region #-- let's look in the wireless node connections for a parent --#
-                    adi: dict[str, Any] | None = next((adi for adi in node_or_device.adapter_info), None)
-                    if adi is not None:
+                    adapter_macs: set[str] = {
+                        adi.get("mac") for adi in node_or_device.adapter_info if adi.get("mac") is not None
+                    }
+                    if adapter_macs:
                         for nwc in ret.get(MeshCapability.GET_NETWORK_CONNECTIONS.value, {}).get(
                             "nodeWirelessConnections", []
                         ):
-                            p_details: dict[str, Any] | None = next(
-                                (pd for pd in nwc.get("connections", []) if pd.get("macAddress") == adi.get("mac")),
-                                None,
-                            )
-                            if p_details is not None:
+                            if any(pd.get("macAddress") in adapter_macs for pd in nwc.get("connections", [])):
                                 parent_node = nwc.get("deviceID")
                                 break
                     # endregion
@@ -495,7 +493,7 @@ class Mesh:
                 )
             if isinstance(parent_node, NodeEntity):
                 node_or_device._update_parent(parent_node)
-                if isinstance(node_or_device, DeviceEntity):
+                if isinstance(node_or_device, DeviceEntity) and node_or_device.status:
                     parent_node._update_connected_devices(node_or_device)
 
         # endregion


### PR DESCRIPTION
## Summary

Preserve best-effort device Parent resolution while keeping a node's
`connected_devices` limited to devices considered currently online.

## Context

#255 added a fallback that derives Parent from `nodeWirelessConnections` when
`GetDevices` does not provide a usable parent.

After the bidirectional relationship work in #258, #259 restricted device
parent processing to devices whose `DeviceEntity.status` is true. I understand
the purpose of that restriction: cached or offline wireless records should not
populate a node's current `connected_devices`.

Because `DeviceEntity.status` is derived from whether `GetDevices.connections`
is populated, the restriction also prevents the Parent fallback from running
in the bridge-mode case #255 was intended to cover.

In a current capture:

- 50 clients appear in `nodeWirelessConnections`;
- only 4 have non-empty `GetDevices.connections`;
- Parent resolves for those same 4, while the other 46 remain unknown.

The affected clients have the same input shape as the sanitized example
documented in #255.

## Change

- Resolve a device's Parent independently of `DeviceEntity.status`.
- Preserve matching against all of the device's known adapter MACs.
- Update the parent node's `connected_devices` only when `device.status` is
  true.

Explicit parent information remains authoritative. This does not change device
status, online-device generation, or connected-device counts.

## Intended semantics

This treats Parent as a best-effort, potentially last-known association while
treating `connected_devices` as current-online membership. My intent is to
preserve the protection introduced in #259 while restoring the narrower
fallback accepted in #255.

If #259 intentionally changed Parent itself to current-online-only, then my
interpretation is incorrect and I'm happy to close this PR.

## Validation

- Reproduced the missing Parent on the unmodified 2026.8.8 processing path with
  sanitized fixture data.
- Verified that a device with empty `GetDevices.connections` resolves Parent
  from a matching wireless record without becoming online or appearing in
  `connected_devices`.
- Verified online wireless fallback, explicit-parent precedence, matching
  across multiple known adapters, and unmatched-device behavior.
- Passed Ruff lint and touched-file formatting checks.
- Passed Python compilation.
- Successfully built the source distribution and wheel with `uv build`.

The repository-wide Ruff formatting check continues to flag the existing
formatting of one nested f-string in `pyvelop/__main__.py`; this PR does not
touch that file.

## AI assistance

This change and its description were prepared with assistance from OpenAI
Codex. The contributor reviewed the resulting diff and validation evidence
before submission.
