### PR TITLE
feat: add audit history for attributes

### DIFF
--- a/pyvelop/__main__.py
+++ b/pyvelop/__main__.py
@@ -34,6 +34,7 @@ from .mesh import (
     SpeedtestExitCode,
     SpeedtestResult,
 )
+from .mesh_attribute import MeshAttribute
 from .mesh_entity import DeviceEntity, NodeEntity, ParentalControl, Weekdays
 
 # endregion
@@ -164,6 +165,19 @@ class AllowedChecks(StrEnum):
 _LOGGER = logging.getLogger(f"{__package__}.cli")
 
 
+def get_properties[T](cls: type[T]) -> set[str]:
+    """Retrieve the properties for the given class."""
+
+    _props: set[str] = set()
+
+    for b in cls.mro():
+        for name, val in b.__dict__.items():
+            if isinstance(val, property):
+                _props.add(name)
+
+    return _props
+
+
 @click.group()
 @click.version_option(package_name=__package__)
 def cli() -> None:
@@ -174,6 +188,26 @@ def cli() -> None:
 @click.help_option()
 async def device_group() -> None:
     """Work with devices on the mesh."""
+
+
+@device_group.command(cls=StandardCommand, name="attribute")
+@click.argument("device")
+@click.argument("attribute", type=click.Choice(tuple(get_properties(DeviceEntity)), case_sensitive=False))
+@click.pass_context
+async def device_attr(
+    ctx: click.Context,
+    /,
+    device: str,
+    attribute: str,
+    **_: Any,
+) -> None:
+    """Retrieve details about a specific mesh attribute."""
+
+    devices: list[DeviceEntity] | None = await _get_device_details(ctx=ctx, device=(device,))
+    if devices is not None:
+        for found_device in devices:
+            attr: Any = getattr(found_device, attribute, None)
+            _display_attribute(attribute, attr)
 
 
 @device_group.command(cls=StandardCommand, name="delete")
@@ -218,38 +252,38 @@ async def device_details(
             try:
                 data: dict[str, Any] = {
                     "Queried at": found_device.results_time,
-                    "Device ID": found_device.unique_id,
-                    "Online": found_device.status,
-                    "Parent": found_device.parent_name,
-                    "Manufacturer": found_device.manufacturer,
-                    "Model": found_device.model,
-                    "Description": found_device.description,
-                    "Operating system": found_device.operating_system,
-                    "Serial #": found_device.serial,
-                    "Icon type": found_device.ui_type,
+                    "Device ID": found_device.unique_id.value,
+                    "Online": found_device.status.value,
+                    "Parent": found_device.parent_name.value,
+                    "Manufacturer": found_device.manufacturer.value,
+                    "Model": found_device.model.value,
+                    "Description": found_device.description.value,
+                    "Operating system": found_device.operating_system.value,
+                    "Serial #": found_device.serial.value,
+                    "Icon type": found_device.ui_type.value,
                 }
                 _display(
                     outfile,
                     pd.DataFrame.from_dict(data, orient="index", columns=[""]),
                     index=True,
-                    title=found_device.name,
+                    title=found_device.name.value,
                 )
                 _display(
                     outfile,
-                    pd.DataFrame(found_device.adapter_info),
+                    pd.DataFrame(found_device.adapter_info.value),
                     title="# Connections",
                 )
-                if num_blocked_sites := len(found_device.parental_control_schedule.get("blocked_sites", [])) > 0:
+                if num_blocked_sites := len(found_device.parental_control_schedule.value.get("blocked_sites", [])) > 0:
                     _display(
                         outfile,
                         pd.DataFrame(
-                            found_device.parental_control_schedule.get("blocked_sites"),
+                            found_device.parental_control_schedule.value.get("blocked_sites"),
                             columns=["site"],
                         ),
                         title="Parental Control",
                     )
                 if num_blocked_sites == 0 and (
-                    schedule := found_device.parental_control_schedule.get("blocked_internet_access", {})
+                    schedule := found_device.parental_control_schedule.value.get("blocked_internet_access", {})
                 ):
                     _display(
                         outfile,
@@ -264,7 +298,8 @@ async def device_details(
                         index=True,
                     )
             except Exception as exc:
-                _write_error(exc)
+                raise exc
+                # _write_error(exc)
 
 
 @device_group.command(cls=StandardCommand, name="internet_access")
@@ -445,11 +480,11 @@ async def diagnostics(
                             "id": d.unique_id,
                             "name": d.name,
                             "parent": d.parent_name,
-                            "parent_id": next(adi.parent_id for adi in d.adapter_info),
-                            "connection_type": next(adi.type for adi in d.adapter_info),
-                            "mac": next(adi.mac for adi in d.adapter_info),
-                            "ip": next(adi.ip for adi in d.adapter_info),
-                            "ipv6": next(adi.ipv6 for adi in d.adapter_info),
+                            "parent_id": next(adi.parent_id for adi in d.adapter_info.value),
+                            "connection_type": next(adi.type for adi in d.adapter_info.value),
+                            "mac": next(adi.mac for adi in d.adapter_info.value),
+                            "ip": next(adi.ip for adi in d.adapter_info.value),
+                            "ipv6": next(adi.ipv6 for adi in d.adapter_info.value),
                         }
                         for d in ret_devices
                     ]
@@ -599,6 +634,24 @@ async def mesh_action(
         _output(None, json.dumps(ret))
 
 
+@mesh_group.command(cls=StandardCommand, name="attribute")
+@click.argument("attribute", type=click.Choice(tuple(get_properties(Mesh)), case_sensitive=False))
+@click.pass_context
+async def mesh_attr(
+    ctx: click.Context,
+    /,
+    attribute: str,
+    **_: Any,
+) -> None:
+    """Retrieve details about a specific mesh attribute."""
+
+    if mesh_obj := await _async_mesh_connect(ctx):
+        async with mesh_obj:
+            await mesh_obj.async_initialise()
+            attr: Any = getattr(mesh_obj, attribute, None)
+            _display_attribute(attribute, attr)
+
+
 @mesh_group.command(cls=StandardCommand, name="details")
 @click.option("--outfile", default=None, required=False)
 @click.pass_context
@@ -658,7 +711,7 @@ async def mesh_details(
                     title="Capabilities",
                 )
                 if Actions.GET_LED_NIGHT_MODE.key in mesh_obj.capabilities:
-                    data = {"Night mode": mesh_obj.night_mode}
+                    data = {"Night mode": mesh_obj.night_mode.value}
                     _display(
                         outfile,
                         pd.DataFrame.from_dict(data, orient="index", columns=[""]),
@@ -667,10 +720,10 @@ async def mesh_details(
                     )
                 if Actions.GET_SCHEDULED_REBOOT_SETTINGS.key in mesh_obj.capabilities:
                     data = {
-                        "Enabled": mesh_obj.scheduled_reboot_enabled,
+                        "Enabled": mesh_obj.scheduled_reboot_enabled.value,
                         "Interval": (
                             mesh_obj.scheduled_reboot_interval.value
-                            if mesh_obj.scheduled_reboot_interval is not None
+                            if mesh_obj.scheduled_reboot_interval.value is not None
                             else None
                         ),
                     }
@@ -682,10 +735,10 @@ async def mesh_details(
                     )
                 if Actions.GET_WAN_INFO.key in mesh_obj.capabilities:
                     data = {
-                        "Internet connected": mesh_obj.wan_status,
-                        "Bridge mode": mesh_obj.is_in_bridge_mode,
-                        "Public IP": mesh_obj.wan_ip,
-                        "WAN MAC": mesh_obj.wan_mac,
+                        "Internet connected": mesh_obj.wan_status.value,
+                        "Bridge mode": mesh_obj.is_in_bridge_mode.value,
+                        "Public IP": mesh_obj.wan_ip.value,
+                        "WAN MAC": mesh_obj.wan_mac.value,
                     }
                     _display(
                         outfile,
@@ -695,7 +748,7 @@ async def mesh_details(
                     )
                 if Actions.GET_LAN_SETTINGS.key in mesh_obj.capabilities:
                     data = {
-                        "DHCP enabled": mesh_obj.dhcp_enabled,
+                        "DHCP enabled": mesh_obj.dhcp_enabled.value,
                     }
                     _display(
                         outfile,
@@ -706,16 +759,16 @@ async def mesh_details(
                     _display(
                         outfile,
                         pd.DataFrame(
-                            mesh_obj.dhcp_reservations,
-                            index=pd.RangeIndex(start=1, stop=(len(mesh_obj.dhcp_reservations) + 1)),
+                            mesh_obj.dhcp_reservations.value,
+                            index=pd.RangeIndex(start=1, stop=(len(mesh_obj.dhcp_reservations.value) + 1)),
                         ),
                         index=True,
                         title="DHCP Reservations",
                     )
                 if Actions.GET_TOPOLOGY_OPTIMISATION_SETTINGS.key in mesh_obj.capabilities:
                     data = {
-                        "Client steering enabled": mesh_obj.client_steering_enabled,
-                        "Node steering enabled": mesh_obj.node_steering_enabled,
+                        "Client steering enabled": mesh_obj.client_steering_enabled.value,
+                        "Node steering enabled": mesh_obj.node_steering_enabled.value,
                     }
                     _display(
                         outfile,
@@ -724,7 +777,9 @@ async def mesh_details(
                         title="Topology Optimisation Settings",
                     )
                 if Actions.GET_MLO_SETTINGS.key in mesh_obj.capabilities:
-                    data = {"Enabled": (mesh_obj.mlo_state if mesh_obj.mlo_state is not None else "Unsupported")}
+                    data = {
+                        "Enabled": (mesh_obj.mlo_state.value if mesh_obj.mlo_state.value is not None else "Unsupported")
+                    }
                     _display(
                         outfile,
                         pd.DataFrame.from_dict(data, orient="index", columns=[""]),
@@ -733,8 +788,8 @@ async def mesh_details(
                     )
                 if Actions.GET_EXPRESS_FORWARDING.key in mesh_obj.capabilities:
                     data = {
-                        "Supported": mesh_obj.express_forwarding_supported,
-                        "Enabled": mesh_obj.express_forwarding_enabled,
+                        "Supported": mesh_obj.express_forwarding_supported.value,
+                        "Enabled": mesh_obj.express_forwarding_enabled.value,
                     }
                     _display(
                         outfile,
@@ -744,7 +799,7 @@ async def mesh_details(
                     )
                 if Actions.GET_PARENTAL_CONTROL_INFO.key in mesh_obj.capabilities:
                     data = {
-                        "Enabled": mesh_obj.parental_control_enabled,
+                        "Enabled": mesh_obj.parental_control_enabled.value,
                     }
                     _display(
                         outfile,
@@ -754,10 +809,12 @@ async def mesh_details(
                     )
                 if Actions.GET_MAC_FILTERING_SETTINGS.key in mesh_obj.capabilities:
                     data = {
-                        "Enabled": mesh_obj.mac_filtering_enabled,
-                        "Mode": mesh_obj.mac_filtering_mode,
+                        "Enabled": mesh_obj.mac_filtering_enabled.value,
+                        "Mode": mesh_obj.mac_filtering_mode.value,
                         "Filters": (
-                            mesh_obj.mac_filtering_addresses if len(mesh_obj.mac_filtering_addresses) > 0 else None
+                            mesh_obj.mac_filtering_addresses.value
+                            if len(mesh_obj.mac_filtering_addresses.value) > 0
+                            else None
                         ),
                     }
                     _display(
@@ -768,7 +825,7 @@ async def mesh_details(
                     )
                 if Actions.GET_WPS_SERVER_SETTINGS.key in mesh_obj.capabilities:
                     data = {
-                        "Enabled": mesh_obj.wps_state,
+                        "Enabled": mesh_obj.wps_state.value,
                     }
                     _display(
                         outfile,
@@ -778,7 +835,7 @@ async def mesh_details(
                     )
                 if Actions.GET_ALG_SETTINGS.key in mesh_obj.capabilities:
                     data = {
-                        "Enabled": mesh_obj.sip_enabled,
+                        "Enabled": mesh_obj.sip_enabled.value,
                     }
                     _display(
                         outfile,
@@ -788,8 +845,8 @@ async def mesh_details(
                     )
                 if Actions.GET_HOMEKIT_SETTINGS.key in mesh_obj.capabilities:
                     data = {
-                        "Enabled": mesh_obj.homekit_enabled,
-                        "Paired": mesh_obj.homekit_paired,
+                        "Enabled": mesh_obj.homekit_enabled.value,
+                        "Paired": mesh_obj.homekit_paired.value,
                     }
                     _display(
                         outfile,
@@ -799,9 +856,9 @@ async def mesh_details(
                     )
                 if Actions.GET_UPNP_SETTINGS.key in mesh_obj.capabilities:
                     data = {
-                        "Enabled": mesh_obj.upnp_enabled,
-                        "allow_change_settings": mesh_obj.upnp_allow_change_settings,
-                        "allow_disable_internet": mesh_obj.upnp_allow_disable_internet,
+                        "Enabled": mesh_obj.upnp_enabled.value,
+                        "allow_change_settings": mesh_obj.upnp_allow_change_settings.value,
+                        "allow_disable_internet": mesh_obj.upnp_allow_disable_internet.value,
                     }
                     _display(
                         outfile,
@@ -810,7 +867,7 @@ async def mesh_details(
                         title="UPnP Settings",
                     )
                 if Actions.GET_DEVICES.key in mesh_obj.capabilities:
-                    data_list: list[str | dict[str, Any]] = [n.name for n in mesh_obj.nodes]
+                    data_list: list[str | dict[str, Any]] = [n.name.value for n in mesh_obj.nodes]
                     _display(
                         outfile,
                         pd.DataFrame(
@@ -825,15 +882,15 @@ async def mesh_details(
                     _display(
                         outfile,
                         pd.DataFrame(
-                            mesh_obj.speedtest_results,
-                            index=pd.RangeIndex(start=1, stop=len(mesh_obj.speedtest_results) + 1),
+                            mesh_obj.speedtest_results.value,
+                            index=pd.RangeIndex(start=1, stop=len(mesh_obj.speedtest_results.value) + 1),
                         ),
                         index=True,
                         title="Speedtest Results",
                     )
                 if Actions.GET_GUEST_NETWORK_INFO.key in mesh_obj.capabilities:
                     data = {
-                        "Enabled": mesh_obj.guest_wifi_enabled,
+                        "Enabled": mesh_obj.guest_wifi_enabled.value,
                     }
                     _display(
                         outfile,
@@ -843,17 +900,21 @@ async def mesh_details(
                     )
                     _display(
                         outfile,
-                        pd.DataFrame.from_dict(cast(dict[str, Any], mesh_obj.guest_wifi_details)),
+                        pd.DataFrame.from_dict(cast(dict[str, Any], mesh_obj.guest_wifi_details.value)),
                         title="# Networks",
                     )
                 if Actions.GET_STORAGE_PARTITIONS.key in mesh_obj.capabilities:
                     _display(
                         outfile,
-                        pd.DataFrame(mesh_obj.storage_available),
+                        pd.DataFrame(mesh_obj.storage_available.value),
                         title="File Shares",
                     )
                 if Actions.GET_DEVICES.key in mesh_obj.capabilities:
-                    data_list = [{"name": d.name, "ip": d.adapter_info[0].ip} for d in mesh_obj.devices if d.status]
+                    data_list = [
+                        {"name": d.name.value, "ip": d.adapter_info.value[0].ip if d.adapter_info else None}
+                        for d in mesh_obj.devices
+                        if d.status.value
+                    ]
                     _display(
                         outfile,
                         pd.DataFrame(
@@ -863,7 +924,7 @@ async def mesh_details(
                         index=True,
                         title="Online Devices",
                     )
-                    data_list = [d.name for d in mesh_obj.devices if not d.status]
+                    data_list = [d.name.value for d in mesh_obj.devices if not d.status.value]
                     _display(
                         outfile,
                         pd.DataFrame(
@@ -1270,6 +1331,26 @@ def _display(
     )
 
     _output(dest, "\n")
+
+
+def _display_attribute(attr_name: str, attr: Any) -> None:
+    """Display the given attribute details."""
+
+    data: list[dict[str, Any]] = []
+    if isinstance(attr, MeshAttribute):
+        for audit_entry in attr.audit:
+            data.append(audit_entry.as_dict())
+    else:
+        data = [{"value": str(attr)}]
+
+    _output(None, f"# {attr_name}\n\n")
+    _display(
+        None,
+        pd.DataFrame(
+            data,
+        ),
+        index=True,
+    )
 
 
 def _output(dest: str | None, contents: str) -> None:

--- a/pyvelop/mesh.py
+++ b/pyvelop/mesh.py
@@ -31,6 +31,7 @@ from .exceptions import (
     MeshInvalidInput,
     MeshNeedsInitialise,
 )
+from .mesh_attribute import AttributeAction, AttributeAuditEntry, MeshAttribute
 from .mesh_entity import (
     AdapterInfo,
     DeviceEntity,
@@ -203,7 +204,7 @@ class Mesh:
             "process_end": None,
             "process_start": None,
         }
-        self._mesh_attributes: dict[str, list[DeviceEntity] | list[NodeEntity] | api.JnapResponse] = {}
+        self._mesh_attributes: dict[str, Any] = {}
         _session: ClientSession = session if session is not None else self.__create_session()
         self._mesh_details: MeshDetails = MeshDetails(
             host=node,
@@ -400,15 +401,14 @@ class Mesh:
             # stamp the gather time into each entity
             entity_data[EntityDataProperties.RESULTS_TIME] = self._last_gather_details.get("gather_end")
             # all details as per the API response get added
-            entity_data.update(entity)
+            entity_data[EntityDataProperties.DEVICE_DETAILS] = entity
             # region #-- process additional information --#
             # this is gathered, infered and linked from other API calls
             if "nodeType" not in entity:
                 # region #-- process end devices connected to the mesh --#
                 # region #-- link up MAC based information --#
                 dev_adapter_macs: list[str] = [
-                    dev_adapter.get("macAddress")
-                    for dev_adapter in entity.get(EntityDataProperties.KNOWN_INTERFACES, [])
+                    dev_adapter.get("macAddress") for dev_adapter in entity.get("knownInterfaces", [])
                 ]
                 dev_pc_schedule: list[dict[str, Any]] = []
                 for dev_mac in dev_adapter_macs:
@@ -457,15 +457,16 @@ class Mesh:
                 # endregion
 
                 # region #-- calculate if there is a firmware update available --#
-                if api.Actions.GET_UPDATE_FIRMWARE_STATE.key in ret:
-                    entity_data[EntityDataProperties.FIRMWARE_DETAILS] = next(
-                        (
-                            fds
-                            for fds in ret[api.Actions.GET_UPDATE_FIRMWARE_STATE.key].get("firmwareUpdateStatus", [])
-                            if fds.get("deviceUUID") == entity.get("deviceID")
-                        ),
-                        {},
-                    )
+                entity_data[EntityDataProperties.FIRMWARE_DETAILS] = next(
+                    (
+                        fds
+                        for fds in ret.get(api.Actions.GET_UPDATE_FIRMWARE_STATE.key, {}).get(
+                            "firmwareUpdateStatus", []
+                        )
+                        if fds.get("deviceUUID") == entity.get("deviceID")
+                    ),
+                    {},
+                )
                 # endregion
                 # endregion
 
@@ -480,30 +481,45 @@ class Mesh:
         # region #-- remedial work for the entities --#
         # handle information here that needs a reference to the DeviceEntity or NodeEntity.
         for node_or_device in mesh_entities:
+            audit_history: list[AttributeAuditEntry] = []
             # region #-- establish the parent/child relationship for entities
-            parent_node: str | NodeEntity | None = None
+            parent_node: str | NodeEntity | None = next(
+                (
+                    conn.get("parentDeviceID")
+                    for conn in node_or_device.raw_details.get(EntityDataProperties.DEVICE_DETAILS, {}).get(
+                        "connections", []
+                    )
+                ),
+                None,
+            )
+            audit_history.append(AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, parent_node))
             if isinstance(node_or_device, NodeEntity):
-                # region #-- use backhaul information to set parent for a node --#
-                parent_ip: str | None = node_or_device.raw_details.get(EntityDataProperties.BACKHAUL, {}).get(
-                    "parentIPAddress"
-                )
-                if parent_ip is not None:
-                    for n in mesh_entities:
-                        if isinstance(n, NodeEntity):
-                            nadi: AdapterInfo | None = next((adi for adi in n.adapter_info if adi.primary), None)
-                            if nadi is not None and parent_ip == nadi.ip:
-                                parent_node = n
-                                break
-                # endregion
+                if not parent_node:
+                    # region #-- use backhaul information to set parent for a node --#
+                    parent_ip: str | None = node_or_device.raw_details.get(EntityDataProperties.BACKHAUL, {}).get(
+                        "parentIPAddress"
+                    )
+                    if parent_ip is not None:
+                        for n in mesh_entities:
+                            if isinstance(n, NodeEntity):
+                                nadi: AdapterInfo | None = next(
+                                    (adi for adi in n.adapter_info.value if adi.primary), None
+                                )
+                                if nadi is not None and parent_ip == nadi.ip:
+                                    parent_node = n
+                                    break
+                    audit_history.append(
+                        AttributeAuditEntry(
+                            EntityDataProperties.BACKHAUL.value, parent_ip, type=AttributeAction.REPLACE
+                        )
+                    )
+                    # endregion
             elif isinstance(node_or_device, DeviceEntity) and node_or_device.status:
-                # region #-- check in the connections list for a parent ID --#
-                parent_node = next(
-                    (conn.get("parentDeviceID") for conn in node_or_device.raw_details.get("connections", [])), None
-                )
-                # endregion
                 if not parent_node:
                     # region #-- let's look in the wireless node connections for a parent --#
-                    adapter_macs: set[str] = {adi.mac for adi in node_or_device.adapter_info if adi.mac is not None}
+                    adapter_macs: set[str] = {
+                        adi.mac for adi in node_or_device.adapter_info.value if adi.mac is not None
+                    }
                     if adapter_macs:
                         for nwc in ret.get(api.Actions.GET_NODE_WIRELESS_CONNECTIONS.key, {}).get(
                             "nodeWirelessConnections", []
@@ -511,6 +527,13 @@ class Mesh:
                             if any(pd.get("macAddress") in adapter_macs for pd in nwc.get("connections", [])):
                                 parent_node = nwc.get("deviceID")
                                 break
+                    audit_history.append(
+                        AttributeAuditEntry(
+                            EntityDataProperties.WIRELESS_CONNECTION_DETAILS.value,
+                            parent_node,
+                            type=AttributeAction.REPLACE,
+                        )
+                    )
                     # endregion
 
             if parent_node and not isinstance(parent_node, NodeEntity):  # we have the ID so let's get the NodeEntity
@@ -518,7 +541,7 @@ class Mesh:
                     NodeEntity | None, next((n for n in mesh_entities if n.unique_id == parent_node), None)
                 )
             if isinstance(parent_node, NodeEntity):
-                node_or_device._update_parent(parent_node)
+                node_or_device._update_parent(MeshAttribute(parent_node, tuple(audit_history)))
                 if isinstance(node_or_device, DeviceEntity):
                     parent_node._update_connected_devices(node_or_device)
 
@@ -688,8 +711,8 @@ class Mesh:
                             dev
                             for dev in all_devices
                             if type(dev) is DeviceEntity
-                            and dev.unique_id is not None
-                            and dev.unique_id.lower() == ident
+                            and dev.unique_id.value is not None
+                            and str(dev.unique_id).lower() == ident
                         ),
                         None,
                     )
@@ -708,7 +731,11 @@ class Mesh:
                             for dev in all_devices
                             if type(dev) is DeviceEntity
                             and next(
-                                (adapter for adapter in dev.adapter_info if str(adapter.mac).strip().lower() == ident),
+                                (
+                                    adapter
+                                    for adapter in dev.adapter_info.value
+                                    if str(adapter.mac).strip().lower() == ident
+                                ),
                                 None,
                             )
                         )
@@ -717,7 +744,7 @@ class Mesh:
                             (
                                 dev
                                 for dev in all_devices
-                                if type(dev) is DeviceEntity and dev.name.strip().lower() == ident
+                                if type(dev) is DeviceEntity and str(dev.name).strip().lower() == ident
                             ),
                             None,
                         )
@@ -729,7 +756,7 @@ class Mesh:
             if len(ret) != len(identity) and raise_for_missing:
                 raise MeshDeviceNotFoundResponse(devices=list(set(identity_formatted).difference(identity_found)))
 
-        ret = sorted(ret, key=lambda device: device.name)
+        ret = sorted(ret, key=lambda device: str(device.name))
 
         return ret
 
@@ -747,10 +774,7 @@ class Mesh:
         """
 
         healthcheck_modules: set[str] | None = set(
-            cast(
-                api.JnapResponse,
-                self._mesh_attributes.get(api.Actions.GET_SPEEDTEST_TYPES.key, {}),
-            ).get("supportedHealthCheckModules", [])
+            self._mesh_attributes.get(api.Actions.GET_SPEEDTEST_TYPES.key, {}).get("supportedHealthCheckModules", [])
         )
 
         if "SpeedTest" not in healthcheck_modules:
@@ -1015,10 +1039,7 @@ class Mesh:
         """
 
         healthcheck_modules: set[str] | None = set(
-            cast(
-                api.JnapResponse,
-                self._mesh_attributes.get(api.Actions.GET_SPEEDTEST_TYPES.key, {}),
-            ).get("supportedHealthCheckModules", [])
+            self._mesh_attributes.get(api.Actions.GET_SPEEDTEST_TYPES.key, {}).get("supportedHealthCheckModules", [])
         )
 
         if "SpeedTest" not in healthcheck_modules:
@@ -1060,7 +1081,7 @@ class Mesh:
 
     @property
     @needs_initialise
-    def check_for_update_status(self) -> bool:
+    def check_for_update_status(self) -> MeshAttribute[bool | None]:
         """Get the state of checking for an update as at the last time details were gathered.
 
         If you need the live state then use the async_get_update_state to re-query the API.
@@ -1068,28 +1089,30 @@ class Mesh:
         :return: True if checking
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_UPDATE_FIRMWARE_STATE.key, {})
+        node_results: list[dict[str, Any]] = self._mesh_attributes.get(
+            api.Actions.GET_UPDATE_FIRMWARE_STATE.key, {}
+        ).get("firmwareUpdateStatus", [])
 
-        node_results = attr.get("firmwareUpdateStatus", [])
         all_states = ["pendingOperation" in node for node in node_results]
-        ret = any(all_states)
+        ret: bool = any(all_states)
 
-        return ret
+        return MeshAttribute[bool | None](ret, (AttributeAuditEntry(api.Actions.GET_UPDATE_FIRMWARE_STATE.key, ret),))
 
     @property
     @needs_initialise
-    def client_steering_enabled(self) -> bool | None:
+    def client_steering_enabled(self) -> MeshAttribute[bool | None]:
         """Return if client steering is enabled.
 
         :return: True if enabled, False otherwise.
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_TOPOLOGY_OPTIMISATION_SETTINGS.key, {}),
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_TOPOLOGY_OPTIMISATION_SETTINGS.key, {}).get(
+            "isClientSteeringEnabled"
         )
 
-        return cast(bool | None, attr.get("isClientSteeringEnabled"))
+        return MeshAttribute[bool | None](
+            attr, (AttributeAuditEntry(api.Actions.GET_TOPOLOGY_OPTIMISATION_SETTINGS.key, attr),)
+        )
 
     @property
     def connected_node(self) -> str:
@@ -1101,7 +1124,7 @@ class Mesh:
 
     @property
     @needs_initialise
-    def devices(self) -> list[DeviceEntity]:
+    def devices(self) -> tuple[DeviceEntity, ...]:
         """Get the devices in the mesh.
 
         The list will be returned in alphabetical order based on the device name.
@@ -1114,27 +1137,24 @@ class Mesh:
             for device in self._mesh_attributes.get(_ATTR_PROCESSED_DEVICES, [])
             if isinstance(device, DeviceEntity)
         ]
-        ret = sorted(ret, key=lambda device: device.name)
-        return ret
+        ret = sorted(ret, key=lambda device: str(device.name))
+        return tuple(ret)
 
     @property
     @needs_initialise
-    def dhcp_enabled(self) -> bool | None:
+    def dhcp_enabled(self) -> MeshAttribute[bool | None]:
         """Return if DHCP is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_LAN_SETTINGS.key, {}),
-        )
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_LAN_SETTINGS.key, {}).get("isDHCPEnabled")
 
-        return cast(bool | None, attr.get("isDHCPEnabled"))
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_LAN_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def dhcp_reservations(self) -> list[dict[str, str]]:
+    def dhcp_reservations(self) -> MeshAttribute[list[dict[str, str]]]:
         """Return the DHCP reservations.
 
         :return: list of DHCP reservation details
@@ -1142,92 +1162,99 @@ class Mesh:
         ret: list[dict[str, str]] = []
         temp_dict: dict[str, str] = {}
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_LAN_SETTINGS.key, {}),
+        all_reservations: list[dict[str, Any]] = (
+            self._mesh_attributes.get(api.Actions.GET_LAN_SETTINGS.key, {})
+            .get("dhcpSettings", {})
+            .get("reservations", [])
         )
 
-        for reservation in attr.get("dhcpSettings", {}).get("reservations", []):
+        for reservation in all_reservations:
             temp_dict = {}
             for key, details in reservation.items():
                 temp_dict[camel_to_snake(key)] = details
             ret.append(temp_dict)
 
-        return ret
+        return MeshAttribute[list[dict[str, str]]](ret, (AttributeAuditEntry(api.Actions.GET_LAN_SETTINGS.key, ret),))
 
     @property
     @needs_initialise
-    def express_forwarding_enabled(self) -> bool | None:
+    def express_forwarding_enabled(self) -> MeshAttribute[bool | None]:
         """Return whether Express Forwarding is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_EXPRESS_FORWARDING.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_EXPRESS_FORWARDING.key, {}).get(
+            "isExpressForwardingEnabled"
+        )
 
-        return attr.get("isExpressForwardingEnabled")
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_EXPRESS_FORWARDING.key, attr),))
 
     @property
     @needs_initialise
-    def express_forwarding_supported(self) -> bool | None:
+    def express_forwarding_supported(self) -> MeshAttribute[bool | None]:
         """Return whether Express Forwarding is supported.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_EXPRESS_FORWARDING.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_EXPRESS_FORWARDING.key, {}).get(
+            "isExpressForwardingSupported"
+        )
 
-        return attr.get("isExpressForwardingSupported")
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_EXPRESS_FORWARDING.key, attr),))
 
     @property
     @needs_initialise
-    def firmware_update_setting(self) -> str | None:
+    def firmware_update_setting(self) -> MeshAttribute[str | None]:
         """Get the current setting for firmware updates.
 
         :return: a lowercase string representing the update method
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_UPDATE_SETTINGS.key, {})
+        ret: str | None = None
+        attr: dict[str, Any] | None = self._mesh_attributes.get(api.Actions.GET_UPDATE_SETTINGS.key)
+        if attr is not None:
+            ret = attr.get("updatePolicy", "").lower()
 
-        return attr.get("updatePolicy", "").lower() or None
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(api.Actions.GET_UPDATE_SETTINGS.key, ret),))
 
     @property
     @needs_initialise
-    def guest_wifi_enabled(self) -> bool | None:
+    def guest_wifi_enabled(self) -> MeshAttribute[bool | None]:
         """Get the state of the guest Wi-Fi.
 
         :return: True if enabled
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_GUEST_NETWORK_INFO.key, {}),
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_GUEST_NETWORK_INFO.key, {}).get(
+            "isGuestNetworkEnabled"
         )
 
-        return cast(bool | None, attr.get("isGuestNetworkEnabled"))
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_GUEST_NETWORK_INFO.key, attr),))
 
     @property
     @needs_initialise
-    def guest_wifi_details(self) -> list[dict[str, str]]:
+    def guest_wifi_details(self) -> MeshAttribute[list[dict[str, str]]]:
         """Get the guest network Wi-Fi details.
 
         :return: A list of dictionaries containing the SSID and band for the networks
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_GUEST_NETWORK_INFO.key, {}),
+        radios: list[dict[str, str | bool]] = self._mesh_attributes.get(api.Actions.GET_GUEST_NETWORK_INFO.key, {}).get(
+            "radios", []
         )
-        radios = cast(list[dict[str, Any]], attr.get("radios", []))
 
-        ret = [
+        ret: list[dict[str, str]] = [
             {
                 "ssid": cast(str, radio.get("guestSSID")),
                 "band": cast(str, radio.get("radioID", "")).split("_")[-1],
             }
             for radio in radios
         ]
-        return ret
+        return MeshAttribute[list[dict[str, str]]](
+            ret, (AttributeAuditEntry(api.Actions.GET_GUEST_NETWORK_INFO.key, ret),)
+        )
 
     @property
     def has_initialised(self) -> bool:
@@ -1243,63 +1270,50 @@ class Mesh:
 
     @property
     @needs_initialise
-    def homekit_enabled(self) -> bool | None:
+    def homekit_enabled(self) -> MeshAttribute[bool | None]:
         """Return if the HomeKit integration is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_HOMEKIT_SETTINGS.key, {}),
-        )
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_HOMEKIT_SETTINGS.key, {}).get("isEnabled")
 
-        return cast(bool | None, attr.get("isEnabled"))
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_HOMEKIT_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def homekit_paired(self) -> bool | None:
+    def homekit_paired(self) -> MeshAttribute[bool | None]:
         """Return if the HomeKit integration is paired.
 
         :return: True if enabled, False otherwise
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_HOMEKIT_SETTINGS.key, {}),
-        )
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_HOMEKIT_SETTINGS.key, {}).get("isPaired")
 
-        return cast(bool | None, attr.get("isPaired"))
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_HOMEKIT_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def is_channel_scan_running(self) -> bool | None:
+    def is_channel_scan_running(self) -> MeshAttribute[bool | None]:
         """Get the current state of channel scanning.
 
         :return: True if enabled, False otherwise
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_CHANNEL_SCAN_STATUS.key, {}),
-        )
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_CHANNEL_SCAN_STATUS.key, {}).get("isRunning")
 
-        return cast(bool | None, attr.get("isRunning"))
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_CHANNEL_SCAN_STATUS.key, attr),))
 
     @property
     @needs_initialise
-    def is_in_bridge_mode(self) -> bool:
+    def is_in_bridge_mode(self) -> MeshAttribute[bool | None]:
         """Return whether the mesh is in bridge mode or not."""
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(
-                api.Actions.GET_WAN_INFO.key,
-                {},
-            ),
+        attr: bool = (
+            self._mesh_attributes.get(api.Actions.GET_WAN_INFO.key, {}).get("detectedWANType", "").lower() == "bridge"
         )
 
-        return cast(str, attr.get("detectedWANType", "")).lower() == "bridge"
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_WAN_INFO.key, attr),))
 
     @property
     def last_gather_details(self) -> dict[str, float | None]:
@@ -1318,81 +1332,79 @@ class Mesh:
 
     @property
     @needs_initialise
-    def mac_filtering_addresses(self) -> list[str]:
+    def mac_filtering_addresses(self) -> MeshAttribute[list[str]]:
         """Get addresses that are configured for MAC filtering.
 
         :return: list of MAC addresses
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_MAC_FILTERING_SETTINGS.key, {}),
+        attr: list[str] = self._mesh_attributes.get(api.Actions.GET_MAC_FILTERING_SETTINGS.key, {}).get(
+            "macAddresses", []
         )
 
-        return cast(list[str], attr.get("macAddresses", []))
+        return MeshAttribute[list[str]](attr, (AttributeAuditEntry(api.Actions.GET_MAC_FILTERING_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def mac_filtering_enabled(self) -> bool:
+    def mac_filtering_enabled(self) -> MeshAttribute[bool | None]:
         """Return if MAC filtering is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_MAC_FILTERING_SETTINGS.key, {}),
+        attr: bool = (
+            self._mesh_attributes.get(api.Actions.GET_MAC_FILTERING_SETTINGS.key, {}).get("macFilterMode", "").lower()
+            != "disabled"
         )
 
-        return cast(str, attr.get("macFilterMode", "")).lower() != "disabled"
+        return MeshAttribute[bool | None](
+            attr, (AttributeAuditEntry(api.Actions.GET_MAC_FILTERING_SETTINGS.key, attr),)
+        )
 
     @property
     @needs_initialise
-    def mac_filtering_mode(self) -> str | None:
+    def mac_filtering_mode(self) -> MeshAttribute[str | None]:
         """Return the MAC filtering mode.
 
         :return: string containing the filtering mode
         """
+
+        ret: str | None = None
         if self.mac_filtering_enabled:
-            attr = cast(
-                dict[str, Any],
-                self._mesh_attributes.get(api.Actions.GET_MAC_FILTERING_SETTINGS.key, {}),
+            ret = (
+                self._mesh_attributes.get(api.Actions.GET_MAC_FILTERING_SETTINGS.key, {})
+                .get("macFilterMode", "")
+                .lower()
             )
 
-            return cast(str, attr.get("macFilterMode", "")).lower()
-
-        return None
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(api.Actions.GET_MAC_FILTERING_SETTINGS.key, ret),))
 
     @property
     @needs_initialise
-    def mlo_state(self) -> bool | None:
+    def mlo_state(self) -> MeshAttribute[bool | None]:
         """Retrieve the state of MLO.
 
         :return: True if enabled, False if disabled and None if not supported.
         """
 
-        # {"isMLOSupported": true,"isMLOEnabled": false}
-
-        ret: bool | None = None
-        mlo_state: dict[str, bool] | None = cast(
-            dict[str, bool] | None,
-            self._mesh_attributes.get(api.Actions.GET_MLO_SETTINGS.key),
+        attr: bool | None = (
+            self._mesh_attributes.get(api.Actions.GET_MLO_SETTINGS.key, {})
+            .get("isMLOSupported", {})
+            .get("isMLOEnabled")
         )
-        if mlo_state is not None:
-            ret = None if not mlo_state.get("isMLOSupported") else mlo_state.get("isMLOEnabled")
 
-        return ret
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_MLO_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def night_mode(self) -> NightModeState | None:
+    def night_mode(self) -> MeshAttribute[NightModeState | None]:
         """Return whether night mode is enabled.
 
         :return: True if enabled, False otherwise
         """
 
         ret: NightModeState | None = None
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_LED_NIGHT_MODE.key)
+        attr: dict[str, bool | int] | None = self._mesh_attributes.get(api.Actions.GET_LED_NIGHT_MODE.key)
 
         if attr is not None:
             if not attr.get("Enable", False):
@@ -1403,91 +1415,106 @@ class Mesh:
                 elif attr.get("StartingTime") == 20 and attr.get("EndingTime") == 8:
                     ret = NightModeState.NIGHT_MODE
 
-        return ret
+        return MeshAttribute[NightModeState | None](
+            ret, (AttributeAuditEntry(api.Actions.GET_LED_NIGHT_MODE.key, ret),)
+        )
 
     @property
     @needs_initialise
-    def node_steering_enabled(self) -> bool | None:
+    def node_steering_enabled(self) -> MeshAttribute[bool | None]:
         """Return if node steering is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_TOPOLOGY_OPTIMISATION_SETTINGS.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_TOPOLOGY_OPTIMISATION_SETTINGS.key, {}).get(
+            "isNodeSteeringEnabled"
+        )
 
-        return attr.get("isNodeSteeringEnabled")
+        return MeshAttribute[bool | None](
+            attr, (AttributeAuditEntry(api.Actions.GET_TOPOLOGY_OPTIMISATION_SETTINGS.key, attr),)
+        )
 
     @property
     @needs_initialise
-    def nodes(self) -> list[NodeEntity]:
+    def nodes(self) -> tuple[NodeEntity, ...]:
         """Get the nodes in the mesh.
 
         The return is sorted in alphabetical order based on node name.
 
-        :return: A list of NodeEntity objects
+        :return: A tuple of NodeEntity objects
         """
         ret: list[NodeEntity] = [
             node for node in self._mesh_attributes.get(_ATTR_PROCESSED_DEVICES, []) if isinstance(node, NodeEntity)
         ]
 
-        ret = sorted(ret, key=lambda node: node.name)
-        return ret
+        ret = sorted(ret, key=lambda node: str(node.name))
+        return tuple(ret)
 
     @property
     @needs_initialise
-    def parental_control_enabled(self) -> bool | None:
+    def parental_control_enabled(self) -> MeshAttribute[bool | None]:
         """Get the state of the Parental Control feature.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_PARENTAL_CONTROL_INFO.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_PARENTAL_CONTROL_INFO.key, {}).get(
+            "isParentalControlEnabled"
+        )
 
-        return attr.get("isParentalControlEnabled")
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_PARENTAL_CONTROL_INFO.key, attr),))
 
     @property
     @needs_initialise
-    def scheduled_reboot_enabled(self) -> bool | None:
+    def scheduled_reboot_enabled(self) -> MeshAttribute[bool | None]:
         """Get the state of the Scheduled Reboot feature.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_SCHEDULED_REBOOT_SETTINGS.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_SCHEDULED_REBOOT_SETTINGS.key, {}).get(
+            "isScheduledRebootEnabled"
+        )
 
-        return attr.get("isScheduledRebootEnabled")
+        return MeshAttribute[bool | None](
+            attr, (AttributeAuditEntry(api.Actions.GET_SCHEDULED_REBOOT_SETTINGS.key, attr),)
+        )
 
     @property
     @needs_initialise
-    def scheduled_reboot_interval(self) -> ScheduledRebootInterval | None:
+    def scheduled_reboot_interval(self) -> MeshAttribute[ScheduledRebootInterval | None]:
         """Get the interval for the Scheduled Reboot feature.
 
         :return: value representing the interval
         """
 
         ret: ScheduledRebootInterval | None = None
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_SCHEDULED_REBOOT_SETTINGS.key, {})
-        val: str | None = attr.get("rebootInterval")
-        if val is not None:
-            ret = ScheduledRebootInterval(val)
+        attr: dict[str, Any] = self._mesh_attributes.get(api.Actions.GET_SCHEDULED_REBOOT_SETTINGS.key, {}).get(
+            "rebootInterval"
+        )
+        if attr is not None:
+            ret = ScheduledRebootInterval(attr)
 
-        return ret
+        return MeshAttribute[ScheduledRebootInterval | None](
+            ret, (AttributeAuditEntry(api.Actions.GET_SCHEDULED_REBOOT_SETTINGS.key, attr),)
+        )
 
     @property
     @needs_initialise
-    def sip_enabled(self) -> bool | None:
+    def sip_enabled(self) -> MeshAttribute[bool | None]:
         """Return whether SIP is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_ALG_SETTINGS.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_ALG_SETTINGS.key, {}).get("isSIPEnabled")
 
-        return attr.get("isSIPEnabled")
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_ALG_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def speedtest_results(self) -> list[SpeedtestResult]:
+    def speedtest_results(self) -> MeshAttribute[list[SpeedtestResult]]:
         """Return the available speedtest results."""
 
         ret: list[SpeedtestResult] = []
@@ -1500,11 +1527,13 @@ class Mesh:
             if sres is not None:
                 ret.append(sres)
 
-        return ret
+        return MeshAttribute[list[SpeedtestResult]](
+            ret, (AttributeAuditEntry(api.Actions.GET_SPEEDTEST_RESULTS.key, ret),)
+        )
 
     @property
     @needs_initialise
-    def storage_available(self) -> list[dict[str, Any]]:
+    def storage_available(self) -> MeshAttribute[list[dict[str, Any]]]:
         """Get available shared partitions.
 
         :return: List of the available storage devices and their properties
@@ -1512,10 +1541,7 @@ class Mesh:
         ret: list[dict[str, Any]] = []
         node: NodeEntity | None
         device: dict[str, Any]
-        storage_available = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(api.Actions.GET_STORAGE_PARTITIONS.key, {}),
-        )
+        storage_available = self._mesh_attributes.get(api.Actions.GET_STORAGE_PARTITIONS.key, {})
 
         for storage_node in storage_available.get("storageNodes", []):
             for device in storage_node.get("storageDevices", []):
@@ -1536,7 +1562,7 @@ class Mesh:
                             {
                                 "available_kb": partition.get("availableKB"),
                                 "ip": next(
-                                    (adapter.ip for adapter in node.adapter_info if adapter.ip),
+                                    (adapter.ip for adapter in node.adapter_info.value if adapter.ip),
                                     None,
                                 ),
                                 "label": partition.get("label"),
@@ -1546,25 +1572,27 @@ class Mesh:
                             }
                         )
 
-        return ret
+        return MeshAttribute[list[dict[str, Any]]](
+            ret, (AttributeAuditEntry(api.Actions.GET_STORAGE_PARTITIONS.key, ret),)
+        )
 
     @property
     @needs_initialise
-    def storage_settings(self) -> dict[str, bool | None]:
+    def storage_settings(self) -> MeshAttribute[dict[str, Any]]:
         """Get the settings for shared partitions.
 
         :return: dictionary of the storage settings
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(
-                api.Actions.GET_STORAGE_SMB_SERVER.key,
-                {},
-            ),
+        attr: dict[str, Any] = self._mesh_attributes.get(
+            api.Actions.GET_STORAGE_SMB_SERVER.key,
+            {},
         )
 
-        return {"anonymous_access": cast(bool | None, attr.get("isAnonymousAccessEnabled"))}
+        return MeshAttribute[dict[str, Any]](
+            {"anonymous_access": attr.get("isAnonymousAccessEnabled")},
+            (AttributeAuditEntry(api.Actions.GET_STORAGE_SMB_SERVER.key, attr),),
+        )
 
     @property
     def timeout(self) -> float:
@@ -1588,128 +1616,102 @@ class Mesh:
 
     @property
     @needs_initialise
-    def upnp_enabled(self) -> bool | None:
+    def upnp_enabled(self) -> MeshAttribute[bool | None]:
         """Return whether UPnP is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_UPNP_SETTINGS.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_UPNP_SETTINGS.key, {}).get("isUPnPEnabled")
 
-        return attr.get("isUPnPEnabled")
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_UPNP_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def upnp_allow_change_settings(self) -> bool | None:
+    def upnp_allow_change_settings(self) -> MeshAttribute[bool | None]:
         """Return whether users can change settings when UPnP is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_UPNP_SETTINGS.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_UPNP_SETTINGS.key, {}).get("canUsersConfigure")
 
-        return attr.get("canUsersConfigure")
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_UPNP_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def upnp_allow_disable_internet(self) -> bool | None:
+    def upnp_allow_disable_internet(self) -> MeshAttribute[bool | None]:
         """Return whether users can change disable the Internet when UPnP is enabled.
 
         :return: True if enabled, False otherwise
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_UPNP_SETTINGS.key, {})
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_UPNP_SETTINGS.key, {}).get(
+            "canUsersDisableWANAccess"
+        )
 
-        return attr.get("canUsersDisableWANAccess")
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_UPNP_SETTINGS.key, attr),))
 
     @property
     @needs_initialise
-    def wan_dns(self) -> list[str]:
+    def wan_dns(self) -> MeshAttribute[list[str]]:
         """Get the WAN DNS servers.
 
         :return: A list containing the IP addresses of the WAN DNS servers
         """
 
-        attr: api.JnapResponse | Any = self._mesh_attributes.get(api.Actions.GET_WAN_INFO.key, {})
+        attr: dict[str, Any] = self._mesh_attributes.get(api.Actions.GET_WAN_INFO.key, {})
+        ret = [val for key, val in attr.get("wanConnection", {}).items() if key.startswith("dnsServer")]
 
-        ret = [
-            cast(str, val)
-            for key, val in cast(dict[str, Any], attr.get("wanConnection", {})).items()
-            if key.startswith("dnsServer")
-        ]
-
-        return ret
+        return MeshAttribute[list[str]](ret, (AttributeAuditEntry(api.Actions.GET_WAN_INFO.key, ret),))
 
     @property
     @needs_initialise
-    def wan_ip(self) -> str | None:
+    def wan_ip(self) -> MeshAttribute[str | None]:
         """Get the WAN IP address.
 
         :return: A string containing the IP address for the WAN
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(
-                api.Actions.GET_WAN_INFO.key,
-                {},
-            ),
-        )
-        return cast(
-            str | None,
-            cast(dict[str, Any], attr.get("wanConnection", {})).get("ipAddress"),
-        )
+        attr = self._mesh_attributes.get(api.Actions.GET_WAN_INFO.key, {}).get("wanConnection", {}).get("ipAddress")
+
+        return MeshAttribute[str | None](attr, (AttributeAuditEntry(api.Actions.GET_WAN_INFO.key, attr),))
 
     @property
     @needs_initialise
-    def wan_mac(self) -> str | None:
+    def wan_mac(self) -> MeshAttribute[str | None]:
         """Get the WAN MAC.
 
         :return: A string containing the MAC address for the WAN adapter
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(
-                api.Actions.GET_WAN_INFO.key,
-                {},
-            ),
-        )
+        attr = self._mesh_attributes.get(api.Actions.GET_WAN_INFO.key, {}).get("macAddress")
 
-        return cast(str, attr.get("macAddress", ""))
+        return MeshAttribute[str | None](attr, (AttributeAuditEntry(api.Actions.GET_WAN_INFO.key, attr),))
 
     @property
     @needs_initialise
-    def wan_status(self) -> bool:
+    def wan_status(self) -> MeshAttribute[bool | None]:
         """Get the status of the WAN.
 
         :return: True if connected, False if not
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(
-                api.Actions.GET_WAN_INFO.key,
-                {},
-            ),
-        )
+        attr = self._mesh_attributes.get(api.Actions.GET_WAN_INFO.key, {}).get("wanStatus", "").lower() == "connected"
 
-        return cast(str, attr.get("wanStatus", "")).lower() == "connected"
+        return MeshAttribute[bool | None](attr, (AttributeAuditEntry(api.Actions.GET_WAN_INFO.key, attr),))
 
     @property
     @needs_initialise
-    def wps_state(self) -> bool:
+    def wps_state(self) -> MeshAttribute[bool | None]:
         """Return if WPS is enabled or not.
 
         :return: True if enabled, False otherwise
         """
 
-        attr = cast(
-            dict[str, Any],
-            self._mesh_attributes.get(
-                api.Actions.GET_WPS_SERVER_SETTINGS.key,
-                {},
-            ),
+        attr: bool | None = self._mesh_attributes.get(api.Actions.GET_WPS_SERVER_SETTINGS.key, {}).get("enabled")
+        ret: MeshAttribute[bool | None] = MeshAttribute[bool | None](
+            attr, (AttributeAuditEntry(api.Actions.GET_WPS_SERVER_SETTINGS.key, attr),)
         )
 
-        return cast(bool, attr.get("enabled", False))
+        return ret

--- a/pyvelop/mesh_attribute.py
+++ b/pyvelop/mesh_attribute.py
@@ -1,0 +1,57 @@
+"""Representation on an attribute for any MeshEntity and the Mesh itself."""
+
+# region #-- imports --#
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum, auto
+from typing import Any
+
+from .action_registry import ActionKey
+
+# endregion
+
+
+class AttributeAction(StrEnum):
+    """Possible actions for the action of an attribute in the audit histroy."""
+
+    INIT = auto()
+    REPLACE = auto()
+    MERGE = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class AttributeAuditEntry[PropType]:
+    """Representation of an audit log entry."""
+
+    source: ActionKey
+    value: PropType
+    type: AttributeAction = field(default=AttributeAction.INIT, kw_only=True)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dictionary representation of the object."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MeshAttribute[PropType]:
+    """Base representation of an attribute."""
+
+    value: PropType
+    audit: tuple[AttributeAuditEntry, ...]
+
+    def __eq__(self, other):
+        """Equal comparison method."""
+
+        return self.value == other
+
+    def __str__(self) -> str:
+        """Return the string representation."""
+
+        return str(self.value)
+
+    def __repr__(self) -> str:
+        """Return the repr string."""
+
+        return f"{self.__class__.__name__}(value={self.value!r})"

--- a/pyvelop/mesh_entity.py
+++ b/pyvelop/mesh_entity.py
@@ -18,6 +18,7 @@ from . import jnap as api
 from .action_registry import ActionKey, Actions, ActionScope
 from .exceptions import MeshException, MeshInvalidInput
 from .logger import Logger
+from .mesh_attribute import AttributeAction, AttributeAuditEntry, MeshAttribute
 
 if TYPE_CHECKING:
     from .mesh import MeshDetails
@@ -53,15 +54,15 @@ class DeviceProperty(StrEnum):
 class EntityDataProperties(StrEnum):
     """Property names to retrieve from raw data."""
 
-    BACKHAUL = "backhaul"
+    BACKHAUL = Actions.GET_BACKHAUL.key
     CONNECTED_ENTITIES = "connected_entities"
-    FIRMWARE_DETAILS = "firmware_details"
-    KNOWN_INTERFACES = "knownInterfaces"
+    DEVICE_DETAILS = Actions.GET_DEVICES.key
+    FIRMWARE_DETAILS = Actions.GET_UPDATE_FIRMWARE_STATE.key
     PARENT_ENTITY = "parent_entity"
-    PARENTAL_CONTROLS = "parental_controls"
-    RESERVATION_DETAILS = "reservation_details"
+    PARENTAL_CONTROLS = Actions.GET_PARENTAL_CONTROL_INFO.key
+    RESERVATION_DETAILS = Actions.GET_LAN_SETTINGS.key
     RESULTS_TIME = "results_time"
-    WIRELESS_CONNECTION_DETAILS = "wireless_connection_details"
+    WIRELESS_CONNECTION_DETAILS = Actions.GET_NODE_WIRELESS_CONNECTIONS.key
 
 
 class NodeType(StrEnum):
@@ -531,14 +532,16 @@ class MeshEntity:
         """
         ret = f"{self.__class__.__name__}: "
         if self.name:
-            ret += self.name
+            ret += str(self.name)
         return ret
 
     def _get_user_property(self, property_name: DeviceProperty) -> str | None:
         """Get the given property from the user properties."""
         ret: str | None = None
 
-        user_properties: list[dict[str, Any]] = self._data.get("properties", [])
+        user_properties: list[dict[str, Any]] = self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get(
+            "properties", []
+        )
         user_prop: list[dict[str, Any]] = [prop for prop in user_properties if prop.get("name") == property_name.value]
         if user_prop:
             ret = user_prop[0].get("value")
@@ -568,7 +571,7 @@ class MeshEntity:
         cur_devices.add(new_device)
         self._data.update({EntityDataProperties.CONNECTED_ENTITIES: cur_devices})
 
-    def _update_parent(self, new_parent: NodeEntity | None) -> None:
+    def _update_parent(self, new_parent: MeshAttribute[NodeEntity | None]) -> None:
         """Set the parent entity for this entity."""
 
         self._data.update({EntityDataProperties.PARENT_ENTITY: new_parent})
@@ -600,94 +603,248 @@ class MeshEntity:
         return resp
 
     @property
-    def adapter_info(self) -> list[AdapterInfo]:
+    def adapter_info(self) -> MeshAttribute[list[AdapterInfo]]:
         """Retrieve details about the entity's adapters.
 
         :return: Adapter details
         """
 
-        ret = []
+        audit_history: list[AttributeAuditEntry] = []
+        ret: list[AdapterInfo] = []
+        props: dict[str, Any] = {}
 
-        # -- get the adapters --#
-        my_adapters: list[dict[str, Any]] = self._data.get(EntityDataProperties.KNOWN_INTERFACES, [])
+        # -- get the adapters based on known interfaces --#
+        my_adapters: list[dict[str, Any]] = self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get(
+            "knownInterfaces", []
+        )
         for adapter in my_adapters:
-            connection_info: list[dict[str, Any]] = [
-                c
-                for c in self._data.get("connections", [])
-                if c.get("macAddress", "").lower() == adapter.get("macAddress", "").lower()
-            ]
-            reservation_info: dict[str, Any] = (
-                self._data.get(EntityDataProperties.RESERVATION_DETAILS, {})
-                if self._data.get(EntityDataProperties.RESERVATION_DETAILS, {}).get("macAddress", "").lower()
-                == adapter.get("macAddress", "").lower()
-                else {}
+            # region #-- derive details from the device details --#
+            connection_info: dict[str, Any] | None = next(
+                (
+                    c
+                    for c in self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("connections", [])
+                    if c.get("macAddress", "").lower() == adapter.get("macAddress", "").lower()
+                ),
+                None,
             )
-            wifi_info: dict[str, Any] = (
-                self._data.get(EntityDataProperties.WIRELESS_CONNECTION_DETAILS, {})
-                if self._data.get(EntityDataProperties.WIRELESS_CONNECTION_DETAILS, {}).get("macAddress", "").lower()
-                == adapter.get("macAddress", "").lower()
-                else {}
-            )
-            signal_strength: SignalStrength | None = self._signal_strength_to_text(
-                wifi_info.get("wireless", {}).get("signalDecibels")
-            )
+            if connection_info is not None:
+                props_ci: dict[str, Any] = {
+                    "band": adapter.get("band"),
+                    "guest_network": connection_info.get("isGuest", False),
+                    "ip": connection_info.get("ipAddress"),
+                    "ipv6": connection_info.get("ipv6Address"),
+                    "mac": adapter.get("macAddress"),
+                }
+                audit_history.append(AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, props_ci))
+                props.update(props_ci)
+            # endregion
 
-            # region #-- infer the adapter connection type if we can --#
+            # region #-- derive reservation information --#
+            reservation_info: dict[str, Any] | None = self._data.get(EntityDataProperties.RESERVATION_DETAILS)
+            if reservation_info is not None:
+                props_reservation: dict[str, Any] = {
+                    "reservation": bool(reservation_info),
+                    "reservation_description": reservation_info.get("description"),
+                }
+                audit_history.append(
+                    AttributeAuditEntry(
+                        EntityDataProperties.RESERVATION_DETAILS.value, props_reservation, type=AttributeAction.MERGE
+                    )
+                )
+                props.update(props_reservation)
+            # endregion
+
+            # region #-- derive wireless information --#
+            wifi_info: dict[str, Any] | None = self._data.get(EntityDataProperties.WIRELESS_CONNECTION_DETAILS)
+            if wifi_info is not None:
+                signal_strength: SignalStrength | None = self._signal_strength_to_text(
+                    wifi_info.get("wireless", {}).get("signalDecibels")
+                )
+                props_wifi: dict[str, Any] = {
+                    "negotiated_mbps": wifi_info.get("negotiatedMbps"),
+                    "rssi_dbm": wifi_info.get("wireless", {}).get("signalDecibels"),
+                    "signal_strength": (signal_strength.value.lower() if signal_strength is not None else None),
+                }
+                audit_history.append(
+                    AttributeAuditEntry(
+                        EntityDataProperties.WIRELESS_CONNECTION_DETAILS.value, props_wifi, type=AttributeAction.MERGE
+                    )
+                )
+                props.update(props_wifi)
+            # endregion
+
+            # region #-- derive the adapter connection type --#
             adapter_conn_type: ConnectionType = ConnectionType(adapter.get("interfaceType", "Unknown"))
             if adapter_conn_type == ConnectionType.UNKNOWN and wifi_info:
                 adapter_conn_type = ConnectionType.WIRELESS
+            props_type: dict[str, Any] = {
+                "type": adapter_conn_type,
+            }
+            audit_history.append(
+                AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, props_type, type=AttributeAction.MERGE)
+            )
+            props.update(props_type)
             # endregion
 
             # region #-- infer the adapter connected state if we can --#
-            adapter_conn_state: bool = bool(connection_info) or bool(wifi_info)
+            adapter_conn_state: bool = bool(connection_info)
+            props_state: dict[str, bool] = {
+                "connected": adapter_conn_state,
+            }
+            audit_history.append(
+                AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, props_state, type=AttributeAction.MERGE)
+            )
+            if not adapter_conn_state and wifi_info:
+                props["connected"] = True
+                audit_history.append(
+                    AttributeAuditEntry(
+                        EntityDataProperties.DEVICE_DETAILS.value, props_state, type=AttributeAction.MERGE
+                    )
+                )
+            props.update(props_state)
             # endregion
 
-            props = {
-                "band": adapter.get("band"),
-                "connected": adapter_conn_state,
-                "guest_network": (None if not connection_info else connection_info[0].get("isGuest", False)),
-                "ip": (None if not connection_info else connection_info[0].get("ipAddress")),
-                "ipv6": (None if not connection_info else connection_info[0].get("ipv6Address")),
-                "mac": adapter.get("macAddress"),
-                "negotiated_mbps": wifi_info.get("negotiatedMbps"),
-                "parent_id": (
-                    cast(NodeEntity, self._data.get(EntityDataProperties.PARENT_ENTITY)).unique_id
-                    if self._data.get(EntityDataProperties.PARENT_ENTITY) is not None
-                    else None
-                ),
-                "reservation": bool(reservation_info),
-                "reservation_description": reservation_info.get("description"),
-                "rssi_dbm": wifi_info.get("wireless", {}).get("signalDecibels"),
-                "signal_strength": (signal_strength.value.lower() if signal_strength is not None else None),
-                "type": adapter_conn_type,
-            }
+            # region #-- parent details --#
+            parent: MeshAttribute[NodeEntity | None] | None = cast(
+                MeshAttribute[NodeEntity | None] | None, self._data.get(EntityDataProperties.PARENT_ENTITY)
+            )
+            props_parent: dict[str, Any] = {}
+            if parent is not None and parent.value is not None:
+                props_parent = {"parent_id": parent.value.unique_id.value}
+            audit_history.append(
+                AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, props_parent, type=AttributeAction.MERGE)
+            )
+            props.update(props_parent)
+            # endregion
 
             ret.append(AdapterInfo(**props))
 
-        return ret
+        return MeshAttribute[list[AdapterInfo]](ret, tuple(audit_history))
 
     @property
-    def name(self) -> str:
+    def description(self) -> MeshAttribute[str | None]:
+        """Get the description.
+
+        :return: Device description as per the mesh
+        """
+
+        attr: str | None = self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("model", {}).get("description")
+
+        return MeshAttribute[str | None](attr, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, attr),))
+
+    @property
+    def manufacturer(self) -> MeshAttribute[str | None]:
+        """Get the node manufacturer.
+
+        :return: String containing the name of the manufacturer
+        """
+
+        ret: str | None = self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("model", {}).get("manufacturer")
+
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, ret),))
+
+    @property
+    def model(self) -> MeshAttribute[str | None]:
+        """Get the model.
+
+        :return: Model as found by the mesh
+        """
+
+        ret: str | None = self._get_user_property(DeviceProperty.MODEL) or self._data.get(
+            EntityDataProperties.DEVICE_DETAILS, {}
+        ).get("model", {}).get("modelNumber")
+
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, ret),))
+
+    @property
+    def name(self) -> MeshAttribute[str]:
         """Retrieve the name of the entity.
 
         :return: The name of the entity
         """
-        ret = self._get_user_property(DeviceProperty.DEVICE_NAME) or self._data.get("friendlyName") or EMPTY_NAME
 
-        return ret
+        audit: list[AttributeAuditEntry] = []
+        name_discovered: str | None = self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("friendlyName")
+        audit.append(AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, name_discovered))
+        name_user: str | None = self._get_user_property(DeviceProperty.DEVICE_NAME)
+        if name_user:
+            audit.append(
+                AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, name_user, type=AttributeAction.REPLACE)
+            )
+
+        ret = name_user or name_discovered or EMPTY_NAME
+
+        return MeshAttribute[str](ret, tuple(audit))
 
     @property
-    def parent_name(self) -> str | None:
+    def parent(self) -> MeshAttribute[NodeEntity | None]:
+        """Return the parent entity."""
+
+        ret: NodeEntity | None = None
+        audit_history: tuple[AttributeAuditEntry, ...] = ()
+        parent: MeshAttribute[NodeEntity | None] | None = self._data.get(EntityDataProperties.PARENT_ENTITY)
+        if parent is not None:
+            ret = parent.value
+            audit_history = parent.audit
+
+        return MeshAttribute[NodeEntity | None](ret, audit_history)
+
+    @property
+    def parent_ip(self) -> MeshAttribute[str | None]:
+        """IP of the parent node.
+
+        :return: The IP of the parent node or None if no node has been identified.
+        """
+
+        audit_history: tuple[AttributeAuditEntry, ...] = ()
+        ret: str | None = None
+        parent: MeshAttribute[NodeEntity | None] | None = self._data.get(EntityDataProperties.PARENT_ENTITY)
+        if parent is not None and parent.value is not None:
+            parent_adi: NodeAdapterInfo | None = next(
+                (adi for adi in parent.value.adapter_info.value if adi.primary), None
+            )
+            if parent_adi is not None:
+                audit_history = parent.value.adapter_info.audit
+                ret = parent_adi.ip
+
+        return MeshAttribute[str | None](ret, tuple(audit_history))
+
+    @property
+    def parent_ipv6(self) -> MeshAttribute[str | None]:
+        """IPv6 of the parent node.
+
+        :return: The IPv6 of the parent node or None if no node has been identified.
+        """
+
+        audit_history: tuple[AttributeAuditEntry, ...] = ()
+        ret: str | None = None
+        parent: MeshAttribute[NodeEntity | None] | None = self._data.get(EntityDataProperties.PARENT_ENTITY)
+        if parent is not None and parent.value is not None:
+            parent_adi: NodeAdapterInfo | None = next(
+                (adi for adi in parent.value.adapter_info.value if adi.primary), None
+            )
+            if parent_adi is not None:
+                audit_history = parent.value.adapter_info.audit
+                ret = parent_adi.ipv6
+
+        return MeshAttribute[str | None](ret, tuple(audit_history))
+
+    @property
+    def parent_name(self) -> MeshAttribute[str | None]:
         """Name of the node the device is connected to.
 
         :return: The parent node name or None if no node has been identified.
         """
 
+        audit_history: tuple[AttributeAuditEntry, ...] = ()
         ret: str | None = None
-        if (parent := self._data.get(EntityDataProperties.PARENT_ENTITY)) is not None:
-            ret = cast(NodeEntity, parent).name
+        parent: MeshAttribute[NodeEntity | None] | None = self._data.get(EntityDataProperties.PARENT_ENTITY)
+        if parent is not None and parent.value is not None:
+            parent_name: MeshAttribute[str] = parent.value.name
+            audit_history = parent_name.audit
+            ret = parent_name.value
 
-        return ret
+        return MeshAttribute[str | None](ret, audit_history)
 
     @property
     def raw_details(self) -> dict[str, Any]:
@@ -704,7 +861,18 @@ class MeshEntity:
         return cast(int | None, self._data.get(EntityDataProperties.RESULTS_TIME))
 
     @property
-    def status(self) -> bool:
+    def serial(self) -> MeshAttribute[str | None]:
+        """Get the serial number of the node.
+
+        :return: A string containing the serial number
+        """
+
+        ret: str | None = self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("unit", {}).get("serialNumber")
+
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, ret),))
+
+    @property
+    def status(self) -> MeshAttribute[bool | None]:
         """Get whether the device is currently connected to the mesh or not.
 
         Assumes that if there are no connections specified for the device then it is offline.
@@ -712,15 +880,22 @@ class MeshEntity:
 
         :return: True if connected. False if not.
         """
-        conns: dict[str, Any] = self._data.get("connections", [])
-        if not conns:  # check if there are wireless connection details
-            conns = self._data.get(EntityDataProperties.WIRELESS_CONNECTION_DETAILS, {})
 
-        ret = True if conns else False
-        return ret
+        audit: list[AttributeAuditEntry] = []
+        conns: bool = bool(self._data.get(EntityDataProperties.DEVICE_DETAILS.value, {}).get("connections", []))
+        audit.append(AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, conns))
+        if not conns:  # check if there are wireless connection details
+            conns = bool(self._data.get(EntityDataProperties.WIRELESS_CONNECTION_DETAILS, {}))
+            audit.append(
+                AttributeAuditEntry(
+                    EntityDataProperties.WIRELESS_CONNECTION_DETAILS.value, conns, type=AttributeAction.REPLACE
+                )
+            )
+
+        return MeshAttribute[bool | None](conns, tuple(audit))
 
     @property
-    def ui_type(self) -> UiType | str | None:
+    def ui_type(self) -> MeshAttribute[UiType | str | None]:
         """Get the type assigned to the device as per the web UI.
 
         :return: The icon slug if available.  None otherwise.
@@ -734,12 +909,17 @@ class MeshEntity:
             except ValueError:
                 ret = ui_type
 
-        return ret
+        return MeshAttribute[UiType | str | None](
+            ret, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, ret),)
+        )
 
     @property
-    def unique_id(self) -> str | None:
+    def unique_id(self) -> MeshAttribute[str | None]:
         """Return the unique id of the entity."""
-        return cast(str | None, self._data.get("deviceID"))
+
+        ret: str | None = self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("deviceID")
+
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, ret),))
 
 
 class DeviceEntity(MeshEntity):
@@ -785,7 +965,7 @@ class DeviceEntity(MeshEntity):
         :return: None
         """
 
-        await self._async_api_request(api.Actions.DELETE_DEVICE.action, {"deviceID": self.unique_id})
+        await self._async_api_request(api.Actions.DELETE_DEVICE.action, {"deviceID": self.unique_id.value})
 
     async def async_rename(self, name: str) -> None:
         """Set the name of the device.
@@ -796,7 +976,7 @@ class DeviceEntity(MeshEntity):
         """
 
         payload: dict[str, Any] = {
-            "deviceID": self.unique_id,
+            "deviceID": self.unique_id.value,
             "propertiesToModify": [
                 {
                     "name": DeviceProperty.DEVICE_NAME.value,
@@ -825,7 +1005,7 @@ class DeviceEntity(MeshEntity):
             _icon = icon
 
         payload: dict[str, Any] = {
-            "deviceID": self.unique_id,
+            "deviceID": self.unique_id.value,
             "propertiesToModify": [
                 {
                     "name": DeviceProperty.UI_TYPE.value,
@@ -854,7 +1034,7 @@ class DeviceEntity(MeshEntity):
         this_device_rules: list[dict[str, Any]] = []
 
         # region #-- get the device MAC --#
-        device_mac: str | None = self.adapter_info[0].mac
+        device_mac: str | None = self.adapter_info.value[0].mac
         if device_mac is None:
             raise MeshException("No MAC available")
         # endregion
@@ -948,7 +1128,7 @@ class DeviceEntity(MeshEntity):
                 self._async_api_request(
                     api.Actions.SET_DEVICE_PROPERTY.action,
                     {
-                        "deviceID": self.unique_id,
+                        "deviceID": self.unique_id.value,
                         "propertiesToModify": device_properties["modify"],
                     },
                 )
@@ -959,7 +1139,7 @@ class DeviceEntity(MeshEntity):
                 self._async_api_request(
                     api.Actions.SET_DEVICE_PROPERTY.action,
                     {
-                        "deviceID": self.unique_id,
+                        "deviceID": self.unique_id.value,
                         "propertiesToRemove": device_properties["remove"],
                     },
                 )
@@ -993,7 +1173,7 @@ class DeviceEntity(MeshEntity):
         this_device_rules: list[dict[str, Any]] = []
 
         # region #-- get the MAC address details --#
-        device_mac: str | None = self.adapter_info[0].mac
+        device_mac: str | None = self.adapter_info.value[0].mac
         if device_mac is None:
             raise MeshException("No MAC available")
         # endregion
@@ -1066,7 +1246,7 @@ class DeviceEntity(MeshEntity):
                 self._async_api_request(
                     api.Actions.SET_DEVICE_PROPERTY.action,
                     {
-                        "deviceID": self.unique_id,
+                        "deviceID": self.unique_id.value,
                         "propertiesToModify": device_properties["modify"],
                     },
                 )
@@ -1076,7 +1256,7 @@ class DeviceEntity(MeshEntity):
                 self._async_api_request(
                     api.Actions.SET_DEVICE_PROPERTY.action,
                     {
-                        "deviceID": self.unique_id,
+                        "deviceID": self.unique_id.value,
                         "propertiesToRemove": device_properties["remove"],
                     },
                 )
@@ -1086,53 +1266,19 @@ class DeviceEntity(MeshEntity):
         await asyncio.gather(*requests)
 
     @property
-    def description(self) -> str | None:
-        """Get the description.
-
-        :return: Device description as per the mesh
-        """
-        return cast(str | None, self._data.get("model", {}).get("description", None))
-
-    @property
-    def manufacturer(self) -> str | None:
-        """Get the manufacturer.
-
-        :return: Manufacturer as found by the mesh
-        """
-
-        ret: str | None = self._get_user_property(DeviceProperty.MANUFACTURER) or self._data.get("model", {}).get(
-            "manufacturer", None
-        )
-
-        return ret
-
-    @property
-    def model(self) -> str | None:
-        """Get the model.
-
-        :return: Model as found by the mesh
-        """
-
-        ret: str | None = self._get_user_property(DeviceProperty.MODEL) or self._data.get("model", {}).get(
-            "modelNumber", None
-        )
-
-        return ret
-
-    @property
-    def operating_system(self) -> str | None:
+    def operating_system(self) -> MeshAttribute[str | None]:
         """Get the OS.
 
         :return: The OS as identified by the mesh
         """
-        ret: str | None = self._get_user_property(DeviceProperty.OPERATING_SYSTEM) or self._data.get("unit", {}).get(
-            "operatingSystem", None
-        )
+        ret: str | None = self._get_user_property(DeviceProperty.OPERATING_SYSTEM) or self._data.get(
+            EntityDataProperties.DEVICE_DETAILS, {}
+        ).get("unit", {}).get("operatingSystem")
 
-        return ret
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, ret),))
 
     @property
-    def parental_control_schedule(self) -> dict[str, Any]:
+    def parental_control_schedule(self) -> MeshAttribute[dict[str, Any]]:
         """Return the schedule of the parental controls for the device.
 
         An empty dictionary means that there are no parental controls in place
@@ -1147,12 +1293,9 @@ class DeviceEntity(MeshEntity):
                 "blocked_sites": pc_details.blocked_urls,
             }
 
-        return ret
-
-    @property
-    def serial(self) -> str | None:
-        """Get the serial number."""
-        return cast(str | None, self._data.get("unit", {}).get("serialNumber", None))
+        return MeshAttribute[dict[str, Any]](
+            ret, (AttributeAuditEntry(EntityDataProperties.PARENTAL_CONTROLS.value, ret),)
+        )
 
 
 class NodeEntity(MeshEntity):
@@ -1168,7 +1311,7 @@ class NodeEntity(MeshEntity):
 
         # region #-- establish the correct IP to use --#
         target_ip: str | None = next(
-            (adapter.ip for adapter in self.adapter_info if adapter.ip and adapter.primary),
+            (adapter.ip for adapter in self.adapter_info.value if adapter.ip and adapter.primary),
             None,
         )
         if not target_ip:
@@ -1199,7 +1342,7 @@ class NodeEntity(MeshEntity):
 
         # region #-- establish the correct IP to use --#
         target_ip: str | None = next(
-            (adapter.ip for adapter in self.adapter_info if adapter.ip and adapter.primary),
+            (adapter.ip for adapter in self.adapter_info.value if adapter.ip and adapter.primary),
             None,
         )
         if not target_ip:
@@ -1213,27 +1356,41 @@ class NodeEntity(MeshEntity):
         _LOGGER.debug(self._log_formatter.format("exited"))
 
     @property
-    def adapter_info(self) -> list[NodeAdapterInfo]:
+    def adapter_info(self) -> MeshAttribute[list[NodeAdapterInfo]]:
         """Retrieve details about the entity's adapters.
 
         :return: Adapter details including reservation, Wi-Fi, IP and Guest details.
             Additionally includes whether it is the primary adapter or not.
         """
 
+        super_adapters: MeshAttribute[list[AdapterInfo]] = super().adapter_info
+
+        audit_history: list[AttributeAuditEntry] = list(super_adapters.audit)
         ret: list[NodeAdapterInfo] = []
-        super_adapters: list[AdapterInfo] = super().adapter_info
         backhaul: dict[str, Any] = self._data.get(EntityDataProperties.BACKHAUL, {})
-        for adapter in super_adapters:
+        for adapter in super_adapters.value:
             props: dict[str, Any] = asdict(adapter)
-            props.update(
-                {"primary": True if adapter.ip == backhaul.get("ipAddress") or self.type == NodeType.PRIMARY else False}
-            )
+            props_primary: dict[str, bool] = {"primary": False}
+            if adapter.ip == backhaul.get("ipAddress"):
+                props_primary["primary"] = True
+                audit_history.append(
+                    AttributeAuditEntry(EntityDataProperties.BACKHAUL.value, props_primary, type=AttributeAction.MERGE)
+                )
+            elif self.type == NodeType.PRIMARY:
+                props_primary["primary"] = True
+                audit_history.append(
+                    AttributeAuditEntry(
+                        EntityDataProperties.DEVICE_DETAILS.value, props_primary, type=AttributeAction.MERGE
+                    )
+                )
+            props.update(props_primary)
+
             ret.append(NodeAdapterInfo(**props))
 
-        return ret
+        return MeshAttribute[list[NodeAdapterInfo]](ret, tuple(audit_history))
 
     @property
-    def backhaul(self) -> BackhaulInfo | None:
+    def backhaul(self) -> MeshAttribute[BackhaulInfo | None]:
         """Get details about the backhaul."""
         ret: BackhaulInfo | None = None
         backhaul = self._data.get(EntityDataProperties.BACKHAUL, {})
@@ -1257,10 +1414,10 @@ class NodeEntity(MeshEntity):
                 }
             )
 
-        return ret
+        return MeshAttribute[BackhaulInfo | None](ret, (AttributeAuditEntry(EntityDataProperties.BACKHAUL.value, ret),))
 
     @property
-    def connected_devices(self) -> list[DeviceEntity]:
+    def connected_devices(self) -> set[DeviceEntity]:
         """List of the devices that are connected to the node.
 
         :return: List of connected devices in alphabetical order sorted by device name
@@ -1269,10 +1426,10 @@ class NodeEntity(MeshEntity):
         ret: list[DeviceEntity] = []
         ret = sorted(self._data.get(EntityDataProperties.CONNECTED_ENTITIES, []), key=lambda device: device.name)
 
-        return ret
+        return set(ret)
 
     @property
-    def firmware(self) -> dict[str, Any]:
+    def firmware(self) -> MeshAttribute[dict[str, Any]]:
         """Get the firmware details for the node.
 
         N.B. The date doesn't seem to correlate to anything that I can see (I would have thought it was a build
@@ -1280,78 +1437,61 @@ class NodeEntity(MeshEntity):
 
         :return: A dictionary containing the firmware version and date
         """
-        ret = {}
-        if (unit_details := self._data.get("unit")) is not None:
-            ret["version"] = unit_details.get("firmwareVersion")
-            ret["date"] = unit_details.get("firmwareDate")
-        available_updates = self._data.get("firmware_updates", {}).get("availableUpdate", {})
-        if available_updates:
-            ret["latest_version"] = available_updates["firmwareVersion"]
-            ret["latest_date"] = available_updates["firmwareDate"]
-        else:
-            ret["latest_version"] = ret.get("version", None)
-            ret["latest_date"] = ret.get("date", None)
-        return ret
+
+        audit_history: list[AttributeAuditEntry] = []
+        ret: dict[str, Any] = {}
+        if (unit_details := self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("unit")) is not None:
+            props_device: dict[str, Any] = {
+                "version": unit_details.get("firmwareVersion"),
+                "date": unit_details.get("firmwareDate"),
+            }
+            audit_history.append(
+                AttributeAuditEntry(
+                    EntityDataProperties.DEVICE_DETAILS.value,
+                    props_device,
+                )
+            )
+            ret.update(props_device)
+        available_updates = self._data.get(EntityDataProperties.FIRMWARE_DETAILS, {}).get("availableUpdate")
+        if available_updates is not None:
+            props_available: dict[str, Any] = {
+                "latest_version": available_updates.get("firmwareVersion"),
+                "latest_date": available_updates.get("firmwareDate"),
+            }
+            audit_history.append(
+                AttributeAuditEntry(
+                    EntityDataProperties.DEVICE_DETAILS.value, props_available, type=AttributeAction.MERGE
+                )
+            )
+            ret.update(props_available)
+        return MeshAttribute[dict[str, Any]](ret, tuple(audit_history))
 
     @property
-    def hardware_version(self) -> str | None:
+    def hardware_version(self) -> MeshAttribute[str | None]:
         """Get the hardware version of the node.
 
         :return: A string containing the hardware version
         """
-        return cast(str | None, self._data.get("model", {}).get("hardwareVersion"))
+
+        ret: str | None = (
+            self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("model", {}).get("hardwareVersion")
+        )
+
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, ret),))
 
     @property
-    def last_update_check(self) -> str | None:
+    def last_update_check(self) -> MeshAttribute[str | None]:
         """Get the last time an update was checked for.
 
         :return: String containing the last update time as per the API
         """
-        ret = cast(
-            str | None,
-            self._data.get("firmware_updates", {}).get("lastSuccessfulCheckTime"),
-        )
-        return ret
+
+        ret: str | None = self._data.get(EntityDataProperties.FIRMWARE_DETAILS, {}).get("lastSuccessfulCheckTime")
+
+        return MeshAttribute[str | None](ret, (AttributeAuditEntry(EntityDataProperties.FIRMWARE_DETAILS.value, ret),))
 
     @property
-    def manufacturer(self) -> str | None:
-        """Get the node manufacturer.
-
-        :return: String containing the name of the manufacturer
-        """
-        return cast(str | None, self._data.get("model", {}).get("manufacturer"))
-
-    @property
-    def model(self) -> str | None:
-        """Get the model of the node.
-
-        :return: A string containing the model
-        """
-        return cast(str | None, self._data.get("model", {}).get("modelNumber"))
-
-    @property
-    def parent_ip(self) -> str | None:
-        """IP of the parent node.
-
-        :return: The IP of the parent node or None if no node has been identified.
-        """
-
-        ret: str | None = None
-        if (parent := self._data.get(EntityDataProperties.PARENT_ENTITY)) is not None:
-            ret = next((adi.ip for adi in cast(NodeEntity, parent).adapter_info if adi.primary), None)
-
-        return ret
-
-    @property
-    def serial(self) -> str | None:
-        """Get the serial number of the node.
-
-        :return: A string containing the serial number
-        """
-        return cast(str | None, self._data.get("unit", {}).get("serialNumber"))
-
-    @property
-    def type(self) -> NodeType:
+    def type(self) -> MeshAttribute[NodeType]:
         """Get the node type.
 
         The node types are represented as primary or secondary.
@@ -1359,9 +1499,12 @@ class NodeEntity(MeshEntity):
         :return: A NodeType enumeration containing the node type.
         """
         ret = NodeType.UNKNOWN
-        native_type = self._data.get("nodeType", "").lower()
+        native_type = self._data.get(EntityDataProperties.DEVICE_DETAILS, {}).get("nodeType", "").lower()
         if native_type == "master":
             ret = NodeType.PRIMARY
         elif native_type == "slave":
             ret = NodeType.SECONDARY
-        return ret
+
+        return MeshAttribute[NodeType](
+            ret, (AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, native_type),)
+        )


### PR DESCRIPTION
This introduces `MeshAttribute` which returns the value of the attribute alongside any audit history detailing how the value was reached.  This can be useful for troubleshooting and understanding where there is linkage and inference.