### PR TITLE
fix: ensure `MeshEntity.name` is fully audited

### DIFF
--- a/pyvelop/mesh_entity.py
+++ b/pyvelop/mesh_entity.py
@@ -876,6 +876,11 @@ class MeshEntity:
 
         ret = name_user or name_discovered or EMPTY_NAME
 
+        if ret == EMPTY_NAME:
+            audit.append(
+                AttributeAuditEntry(EntityDataProperties.DEVICE_DETAILS.value, EMPTY_NAME, type=AttributeAction.REPLACE)
+            )
+
         return MeshAttribute[str](ret, tuple(audit))
 
     @property


### PR DESCRIPTION
Currently the fallback name is flagged as coming from `GET_DEVICES` - technically this isn't correct but this is done in lieu of having a valid source that it can come from (need to look at that).